### PR TITLE
fix: resolve CI type-check errors (lodash types, Buffer→Uint8Array)

### DIFF
--- a/app/routes/[favicon.ico].tsx
+++ b/app/routes/[favicon.ico].tsx
@@ -5,7 +5,7 @@ export const loader: LoaderFunction = async (): Promise<Response> => {
   const favicon = await getFavicon();
   if (!favicon) return new Response("No favicon found", { status: 404 });
   return new Response(
-    favicon.buffer,
+    new Uint8Array(favicon.buffer),
     favicon.contentType
       ? { headers: { "Content-Type": favicon.contentType } }
       : undefined

--- a/app/routes/[objects.inv].tsx
+++ b/app/routes/[objects.inv].tsx
@@ -4,5 +4,5 @@ import { getObjectsInv } from "~/backend/loaders.server";
 export const loader: LoaderFunction = async (): Promise<Response> => {
   const inv = await getObjectsInv();
   if (!inv) return new Response("Inventory not found", { status: 404 });
-  return new Response(inv);
+  return new Response(new Uint8Array(inv));
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@remix-run/eslint-config": "~1.19.0",
         "@remix-run/serve": "~1.19.0",
         "@tailwindcss/typography": "^0.5.16",
+        "@types/lodash.throttle": "^4.1.9",
         "@types/node-fetch": "^2.6.12",
         "@types/react": "^18.2.24",
         "@types/react-dom": "^18.2.8",
@@ -48,7 +49,7 @@
         "tailwindcss": "^3.4.17"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -10736,6 +10737,16 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
       "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/lodash.throttle": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.throttle/-/lodash.throttle-4.1.9.tgz",
+      "integrity": "sha512-PCPVfpfueguWZQB7pJQK890F2scYKoDUL3iM522AptHWn7d5NQmeS/LTEHIcLr5PaTzl3dK2Z0xSUHHTHwaL5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mapbox__point-geometry": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@remix-run/eslint-config": "~1.19.0",
     "@remix-run/serve": "~1.19.0",
     "@tailwindcss/typography": "^0.5.16",
+    "@types/lodash.throttle": "^4.1.9",
     "@types/node-fetch": "^2.6.12",
     "@types/react": "^18.2.24",
     "@types/react-dom": "^18.2.8",


### PR DESCRIPTION
## Fix CI Type-Check Errors

The new CI pipeline (PR #31) correctly caught 3 pre-existing TypeScript errors that were previously invisible (no CI existed before).

### Fixes

1. **`@types/lodash.throttle`** — Added as devDependency. `@myst-theme/site` ships `.tsx` source files (not compiled `.d.ts`), so TypeScript follows imports into the package and needs this type declaration.

2. **`Buffer` → `Uint8Array`** in `[objects.inv].tsx` and `[favicon.ico].tsx` — Newer `@types/node` no longer allows `Buffer` as a `BodyInit` argument to `new Response()`. Wrapping with `new Uint8Array()` is the correct fix since `Uint8Array` satisfies `BufferSource` which is part of `BodyInit`.

### Verification

Both `npm run compile` and `npm run prod:build` pass cleanly after these changes.
