### PR TITLE
docs: Keep a Changelog rewrite + feature-parity PLAN.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,55 +1,100 @@
-# @curvenote/quantecon-book
+# Changelog
 
-## 1.1.1
+All notable changes to `@curvenote/quantecon-book` (the QuantEcon MyST theme) are
+documented in this file.
 
-### Patch Changes
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-- 6e39113: Fix colab link for lecture repo ending with .myst
+> **Release flow.** This theme is developed here in `quantecon-theme-src` and
+> deployed (bundled) to [`QuantEcon/quantecon-theme`](https://github.com/QuantEcon/quantecon-theme)
+> via `make deploy`. The deploy step copies this file into the bundled repo, so this
+> is the canonical changelog. Versions are tagged from `package.json`.
 
-## 1.1.0
+## [Unreleased]
 
-### Minor Changes
+> Proposed release: **1.2.0**. This is the substantial `@myst-theme` 0.14 → 1.x
+> upgrade plus a technical-review pass. The currently deployed bundle
+> (`QuantEcon/quantecon-theme`) is still **v1.1.1** and predates all of the
+> changes below — a `make deploy` is required to ship them.
 
-- df3bcd4: Update to 0.14.0
+### Changed
+- Upgrade all `@myst-theme/*` packages from `0.14.x` to `1.1.2`, and `myst-common`/`myst-config` to `1.8.1`, aligning with the upstream [`myst-theme/book`](https://github.com/jupyter-book/myst-theme/tree/main/themes/book) template ([#30](https://github.com/QuantEcon/quantecon-theme-src/pull/30)). **Upstream breaking change:** `@myst-theme` v1.0.0 introduced a new AST structure for notebook output nodes ([jupyter-book/myst-theme#571](https://github.com/jupyter-book/myst-theme/pull/571)).
+- Bump all six `@remix-run/*` packages from `~1.17.0` to `~1.19.0` (still Remix v1) to resolve an `ERESOLVE` peer-dependency conflict with `@myst-theme/site` ([#29](https://github.com/QuantEcon/quantecon-theme-src/pull/29)).
+- Raise the Node engine requirement from `>=14` to `>=18` (required by Remix 1.19); add `.nvmrc` pinned to `18`; bump release-workflow actions v3 → v4 ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
 
-## 1.0.6
+### Added
+- CI workflow (`.github/workflows/ci.yml`) running type-check (`npm run compile`) and a production build (`npm run prod:build`) on every push/PR to `main` ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
+- `CONTRIBUTING.md` documenting development setup, available scripts, project structure, commit conventions, and the release process ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
 
-### Patch Changes
+### Fixed
+- `aria-label` typo (`aira-label`) in `ProjectFrontmatter.tsx` — the authors section is now exposed to screen readers ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
+- Missing React `key` prop on author `<span>` elements built in a `.reduce()` in `ProjectFrontmatter.tsx` ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
+- Swapped `SidebarToggle.tsx` ARIA labels so each matches its visible icon state ("Show"/"Hide table of contents") ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
+- TypeScript errors surfaced by the new CI: add `@types/lodash.throttle`; wrap `Buffer` in `new Uint8Array(...)` for the `Response` body in the `[objects.inv]` and `[favicon.ico]` routes ([#32](https://github.com/QuantEcon/quantecon-theme-src/pull/32)).
 
-- 9071f34: Update outline text
+### Security
+- Reduced `npm audit` findings from **60 → 34** across [#29](https://github.com/QuantEcon/quantecon-theme-src/pull/29) and [#30](https://github.com/QuantEcon/quantecon-theme-src/pull/30): `prismjs` DOM-clobbering (GHSA-x7hr-w5r2-h6wg), five KaTeX CVEs, and the dompurify/mermaid chain. Added `overrides` for `prismjs` (`^1.30.0`) and `katex` (`^0.16.21`). The remaining findings require the Remix v2 migration ([#28](https://github.com/QuantEcon/quantecon-theme-src/issues/28)) and upstream `@myst-theme` fixes.
 
-## 1.0.5
+### Dependencies
+- Numerous Dependabot updates merged, including `webpack`, `vite`, `vm2`, `tar-fs`, `lodash`/`lodash-es`, `qs`/`express`, `js-yaml`, `form-data`, `brace-expansion`, `@babel/*`, `diff`, and `minimatch`.
 
-### Patch Changes
+## [1.1.1] - 2025-06-12
+> Changeset authored 2025-06; release formally cut 2026-02-25 ([#8](https://github.com/QuantEcon/quantecon-theme-src/pull/8)).
 
-- dd76b21: Change to link provider
+### Fixed
+- Strip the `.myst` suffix from the derived `org/repo` when building Colab / JupyterHub launch URLs, so lecture repos named `lecture-*.myst` produce working notebook links (`6e39113`, [#4](https://github.com/QuantEcon/quantecon-theme-src/pull/4)).
 
-## 1.0.4
+### Removed
+- Dropped the no-longer-needed `@types/react-syntax-highlighter` patch ([#8](https://github.com/QuantEcon/quantecon-theme-src/pull/8)).
 
-### Patch Changes
+## [1.1.0] - 2025-02-28
 
-- 26772b0: Fix slash issue on links
+### Changed
+- Update `@myst-theme/*` to `0.14.0` (`df3bcd4`, [#2](https://github.com/QuantEcon/quantecon-theme-src/pull/2)).
 
-## 1.0.3
+## [1.0.6] - 2025-02-18
 
-### Patch Changes
+### Changed
+- Update the margin Outline ("On this page") text (`9071f34`).
 
-- c0369e8: Fix Home, Contents and ProjectHeader links
+## [1.0.5] - 2025-02-17
 
-## 1.0.2
+### Changed
+- Use `useLinkProvider` for internal links instead of constructing them directly (`dd76b21`).
 
-### Patch Changes
+## [1.0.4] - 2025-02-17
 
-- 73c72f2: Fix baseurl issues in toolbar and outline
+### Fixed
+- Fix a missing slash in generated links (`26772b0`).
 
-## 1.0.1
+## [1.0.3] - 2025-02-17
 
-### Patch Changes
+### Fixed
+- Fix Home, Contents, and ProjectHeader link targets (`c0369e8`).
 
-- Reverting to remix@17
+## [1.0.2] - 2025-02-17
 
-## 1.0.0
+### Fixed
+- Fix `baseurl` handling in the toolbar and outline links (`73c72f2`).
 
-### Major Changes
+## [1.0.1] - 2025-02-17
 
-- 🚀 Initial Version
+### Changed
+- Pin to `remix@1.17` for compatibility (`8066c00`).
+
+## [1.0.0] - 2025-02-14
+
+### Added
+- Initial version of the QuantEcon MyST theme: Remix + `@myst-theme` book theme with QuantEcon branding, toolbar (home, search, fullscreen, font scaling, dark mode, downloads, Colab/JupyterHub launch, edit-on-GitHub), content-driven site footer, and bundled brand assets.
+
+[Unreleased]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.6...v1.1.0
+[1.0.6]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.5...v1.0.6
+[1.0.5]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.4...v1.0.5
+[1.0.4]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/QuantEcon/quantecon-theme-src/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > **Release flow.** This theme is developed here in `quantecon-theme-src` and
 > deployed (bundled) to [`QuantEcon/quantecon-theme`](https://github.com/QuantEcon/quantecon-theme)
 > via `make deploy`. The deploy step copies this file into the bundled repo, so this
-> is the canonical changelog. Versions are tagged from `package.json`.
+> is the canonical changelog. The version comes from `package.json`; each release is a
+> deploy commit (`🚀 vX.Y.Z from <sha>`) in the bundled repo. There are currently no
+> git tags (see Phase 0 in [`PLAN.md`](./PLAN.md)).
 
 ## [Unreleased]
 
@@ -39,8 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Dependencies
 - Numerous Dependabot updates merged, including `webpack`, `vite`, `vm2`, `tar-fs`, `lodash`/`lodash-es`, `qs`/`express`, `js-yaml`, `form-data`, `brace-expansion`, `@babel/*`, `diff`, and `minimatch`.
 
-## [1.1.1] - 2025-06-12
-> Changeset authored 2025-06; release formally cut 2026-02-25 ([#8](https://github.com/QuantEcon/quantecon-theme-src/pull/8)).
+## [1.1.1] - 2025-06-13
+> Deployed to the bundle repo on 2025-06-13. The source version-bump PR
+> ([#8](https://github.com/QuantEcon/quantecon-theme-src/pull/8)) was merged much later,
+> on 2026-02-25, as bookkeeping — it did not change what users were running.
 
 ### Fixed
 - Strip the `.myst` suffix from the derived `org/repo` when building Colab / JupyterHub launch URLs, so lecture repos named `lecture-*.myst` produce working notebook links (`6e39113`, [#4](https://github.com/QuantEcon/quantecon-theme-src/pull/4)).

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,256 @@
+# PLAN — QuantEcon MyST theme feature parity with `quantecon-book-theme`
+
+This plan tracks bringing the MyST theme (this repo, `quantecon-theme-src`, bundled
+to [`QuantEcon/quantecon-theme`](https://github.com/QuantEcon/quantecon-theme)) to
+feature parity with the Sphinx / Jupyter-Book&lt;2 theme
+[`quantecon-book-theme`](https://github.com/QuantEcon/quantecon-book-theme) ahead of
+migrating the QuantEcon lectures to MyST (Jupyter Book ≥ 2).
+
+## Context & the one architectural constraint that shapes everything
+
+The two themes run in fundamentally different environments:
+
+| | `quantecon-book-theme` (Sphinx) | `quantecon-theme-src` (MyST) |
+| --- | --- | --- |
+| Runs | At **build time**, inside the lecture repo | As a **runtime Remix server** consuming pre-built content JSON from the MyST content CDN |
+| Has the git repo? | **Yes** — can shell out to `git` | **No** — only sees per-page `mdast` + `frontmatter` JSON |
+| Customised via | Jinja templates + a Sphinx extension (`__init__.py`) | React/TSX components + `myst.yml` config |
+
+**Consequence:** any feature that derives from the source repo at build time (git
+history, last-modified dates, computed launch paths) **cannot be computed by the
+theme**. It must be injected into the page `frontmatter`/data upstream — either by:
+
+- **(A) a MyST plugin / transform** that runs during `myst build` in the lecture repo
+  and writes the data into each page's frontmatter, or
+- **(B) built-in `mystmd` support** (where it already exists — e.g. frontmatter
+  `date`), or
+- **(C) a CI step** (GitHub Action) that pre-computes the data and feeds it in.
+
+The theme component's job is then only to *render* `page.frontmatter.<field>`. This
+split is called out per phase below. Several phases therefore have an "upstream"
+deliverable in addition to the theme change.
+
+A second cross-cutting consideration: this theme tracks the upstream
+[`jupyter-book/myst-theme`](https://github.com/jupyter-book/myst-theme) `book` theme.
+Before building anything custom, **check whether the feature already exists upstream**
+(or could be contributed upstream rather than forked into QuantEcon-only code).
+
+---
+
+## Feature gap summary
+
+Derived from `quantecon-book-theme` v0.20.3 (see its `README.md`, `docs/user/*`, and
+`src/quantecon_book_theme/`).
+
+| # | Feature | Book-theme | MyST theme | Phase |
+| --- | --- | :---: | :---: | :---: |
+| Git history in lecture headers (last-modified + changelog dropdown) | ✅ | ❌ | **1** |
+| Launch parity — BinderHub + Thebe (live compute) in addition to Colab / private hub | ✅ | ⚠️ partial | **2** |
+| Configurable code highlighting (custom QE tokens vs Pygments styles) | ✅ | ❌ | **3** |
+| Text colour schemes (`seoul256` / `gruvbox` / `none` + custom) | ✅ | ❌ | **3** |
+| Language switcher (multilingual) + `hreflang` SEO tags | ✅ | ❌ | **4** |
+| RTL support (`dir="rtl"`) | ✅ | ❌ | **5** |
+| Collapsible stderr warnings in notebook cells | ✅ | ❓ verify | **6** |
+| Full OpenGraph / Twitter card meta tags | ✅ | ⚠️ partial | **6** |
+| **Already at parity:** dark mode, font scaling, fullscreen, search, "On this page" TOC + back-to-top, contents sidebar, downloads (PDF/notebook), Colab + private JupyterHub launch, edit-on-GitHub, author header, content-driven footer, responsive/mobile | ✅ | ✅ | — |
+
+---
+
+## Phase 0 — Release & deploy hygiene (prerequisite groundwork)
+
+**Why first:** the deployed bundle is stuck at v1.1.1 (June 2025) and predates the
+entire `@myst-theme` 1.x upgrade. Parity work is meaningless until what's already in
+`main` is shipped and the dev/release loop is trustworthy.
+
+- [ ] Cut **1.2.0** (the `@myst-theme` 1.1.2 upgrade + technical-review fixes) — add a
+      changeset, bump `package.json`, sync `template.yml` `version` (currently stale at
+      `1.0.0`), then `make deploy` to refresh `QuantEcon/quantecon-theme`.
+- [ ] Resolve the Changesets ↔ Keep-a-Changelog tension: the new `CHANGELOG.md` is
+      hand-maintained; decide whether `changeset version` should keep prepending (and
+      reconcile the format) or whether the changelog is now manual. Document the choice
+      in `CONTRIBUTING.md`.
+- [ ] Fix naming/branding drift: reconcile the three package names (`@curvenote/quantecon-book`
+      vs `@curvenote-themes/quantecon-theme` vs `template.yml` title), and the stale
+      `curvenote-themes/quantecon` deploy URL in `README.md` (line ~89).
+- [ ] De-duplicate the two "Development" sections in `README.md`.
+- [ ] Triage the ~20 open Dependabot PRs; schedule the Remix v2 migration ([#28]) that
+      unblocks the remaining `npm audit` findings.
+- [ ] Stand up a **visual preview / smoke test** against a real lecture repo (the
+      book-theme uses `quantecon-book-theme-fixtures` + Playwright + Netlify previews —
+      a lighter MyST equivalent would de-risk every subsequent phase).
+
+**Effort:** S–M. **Risk:** low. **Deps:** none.
+
+---
+
+## Phase 1 — Git history in lecture headers ⭐ (flagship)
+
+**Goal:** reproduce the book-theme's page header: a "Last changed: &lt;date&gt;" control
+that expands a changelog dropdown of the last N commits, with clickable commit hashes
+and a "full history" link.
+**Reference:** `quantecon-book-theme/src/quantecon_book_theme/__init__.py`
+(`get_git_last_modified`, `get_git_changelog`, `get_relative_time`) +
+`theme/.../layout.html` lines ~278–305 + `assets/scripts/page-header.js` +
+`docs/user/git-metadata.md`.
+
+**Upstream (build-time) deliverable — required:**
+- [ ] Investigate existing `mystmd` support for last-modified / git metadata in
+      frontmatter before writing anything custom.
+- [ ] If absent, build a **MyST plugin** (option A) that, during `myst build`, runs
+      `git log --follow` per source file and injects into frontmatter, e.g.
+      `frontmatter.last_modified` (ISO + formatted) and
+      `frontmatter.changelog: [{hash, author, date, relative_time, message}]`.
+      Mirror the book-theme's git logic (timeouts, `--follow`, graceful no-git
+      fallback, configurable `max_entries` and date format).
+- [ ] Decide where the plugin lives (a shared `quantecon-myst-plugins` package reused
+      across lecture repos is preferable to per-repo copies).
+
+**Theme (render) deliverable:**
+- [ ] New `app/components/PageHeaderHistory.tsx` (or fold into `ProjectFrontmatter.tsx`)
+      that reads the injected frontmatter and renders the button + collapsible dropdown,
+      with the QuantEcon blue accent, dark mode, keyboard (Esc to close), and ARIA
+      matching the existing toolbar components. Use Radix (already a dependency) for the
+      disclosure.
+- [ ] Build commit/​history URLs from the project `github` field (reuse the `.myst`-suffix
+      handling already in `LaunchButton.tsx`).
+- [ ] Graceful no-op when the frontmatter fields are absent.
+
+**Effort:** M–L (plugin is the bulk). **Risk:** medium (new upstream component).
+**Deps:** Phase 0 preview harness helps validate against a real repo.
+
+---
+
+## Phase 2 — Launch parity (BinderHub + Thebe)
+
+**Goal:** match the book-theme's full launch matrix. Today `LaunchButton.tsx` offers
+**Colab** + **private JupyterHub** only; the book-theme also offers **BinderHub** and
+in-page **Thebe** live compute.
+**Reference:** `quantecon-book-theme/src/quantecon_book_theme/launch.py` (Binder/Hub/
+Colab URL construction, `notebook_interface`, `nb_path_to_notebooks`, `path_to_docs`
+stripping) + `docs/user/launch.md`.
+
+- [ ] **Thebe:** the bundle already ships Thebe assets and `@myst-theme/jupyter` is wired
+      in (`PageContent.tsx` uses `ExecuteScopeProvider`, `NotebookToolbar`). Confirm/enable
+      `myst.yml` `project.jupyter`/`thebe` config path and surface a "live compute" toggle
+      consistent with the toolbar.
+- [ ] **BinderHub:** add a Binder option to the `LaunchButton` radio group; build
+      `…/v2/gh/{org}/{repo}/{branch}?urlpath=…` URLs.
+- [ ] Generalise the hardcoded `.notebooks` suffix and `main` branch
+      (`LaunchButton.tsx:9–11`) into config read from project frontmatter / `myst.yml`,
+      so non-default branches and naming work.
+- [ ] Verify Colab path handling for **nested** lecture dirs (book-theme strips
+      `path_to_docs` and applies `nb_path_to_notebooks`; the MyST version currently uses
+      only `page.location.split('.')[0]`).
+
+**Effort:** M. **Risk:** low–medium. **Deps:** Phase 0.
+
+---
+
+## Phase 3 — Code highlighting + text colour schemes
+
+Two related theming features; bundle together since both touch the CSS/token layer.
+
+**Goal A — configurable code highlighting:** book-theme `qetheme_code_style` toggles
+between custom QuantEcon token colours and any built-in Pygments style.
+**Goal B — text colour schemes:** book-theme ships `seoul256` (default), `gruvbox`,
+`none`, plus a `custom_color_scheme.css` hook, exposed as CSS variables
+(`--qe-literal-color`, emphasis/strong/definition colours).
+**Reference:** book-theme `__init__.py` (`add_pygments_style_class`,
+`setup_pygments_css`, `validate_color_scheme`), `assets/styles/_color-schemes.scss` /
+`_syntax.scss`, `docs/user/code-highlighting.md`, `docs/user/text-color-schemes.md`.
+
+- [ ] Map the book-theme colour-scheme CSS variables onto this theme's Tailwind tokens
+      (`qetext-*`, `qeborder-blue`, …) in `tailwind.config.js` / `styles/app.css`.
+- [ ] Add a `myst.yml`-driven option to select scheme; render a body/root class
+      (`color-scheme-gruvbox`, etc.) the same way the book-theme does.
+- [ ] Decide code-highlighting strategy under MyST (syntax highlighting comes from
+      `@myst-theme`/prism, not Pygments) — likely "QE token theme vs upstream default"
+      rather than a literal Pygments port. Document the mapping.
+
+**Effort:** M. **Risk:** medium (visual regressions — needs the Phase 0 preview).
+**Deps:** Phase 0.
+
+---
+
+## Phase 4 — Internationalisation (language switcher + hreflang)
+
+**Goal:** book-theme v0.20.0 globe-icon dropdown to switch between translated lecture
+sites, plus `<link rel="alternate" hreflang>` head tags for SEO. Only renders with 2+
+languages configured.
+**Reference:** book-theme `_process_languages()` in `__init__.py`, `layout.html`
+hreflang block + language-switcher markup, `assets/scripts/language-switcher.js`,
+`assets/styles/_language-switcher.scss`, `docs/user/rtl-support.md`,
+`docs/developer/multilingual.md` + `infrastructure.md`.
+
+- [ ] Add a `languages` config (list of `{code, name, url}`) to `myst.yml`/site config,
+      surfaced to the theme via the site manifest loader (`loaders.server.ts`).
+- [ ] New toolbar `LanguageSwitcher.tsx` (Radix dropdown), placed consistently in
+      `Toolbar.tsx` / `MobileActionsMenu.tsx`, with keyboard nav + active-language marker.
+- [ ] Inject `hreflang` alternates in `root.tsx` `links`/`meta` for each language +
+      `x-default`.
+
+**Effort:** M. **Risk:** low. **Deps:** none (independent of 1–3).
+
+---
+
+## Phase 5 — RTL support
+
+**Goal:** book-theme `enable_rtl` sets `dir="rtl"` on `<body>` and ships `_rtl.scss`.
+**Reference:** book-theme `layout.html` `body_tag` block + `assets/styles/_rtl.scss` +
+`docs/user/rtl-support.md`.
+
+- [ ] Add a config flag; set `dir="rtl"` on the document in `root.tsx`.
+- [ ] Audit Tailwind utilities for logical-property / RTL correctness (margins, the blue
+      left/right accents, toolbar ordering); add RTL overrides where physical properties
+      leak.
+
+**Effort:** S–M. **Risk:** low. **Deps:** ideally after Phase 4 (often shipped together
+for the same translated sites).
+
+---
+
+## Phase 6 — Meta/SEO + notebook-output polish
+
+**Goal:** close the smaller gaps and verify assumptions.
+
+- [ ] **OpenGraph/Twitter parity:** the book-theme emits a full OG + Twitter card set;
+      `root.tsx` currently uses `getMetaTagsForSite` (title/description/twitter). Add
+      `og:image`/`twitter:image` (logo), `og:type`, `og:site_name`, etc., driven from
+      site config.
+- [ ] **Collapsible stderr warnings:** confirm whether `@myst-theme/jupyter` already
+      renders notebook stderr in a collapsible/styled way (it may — verify before
+      porting). If not, add an output transform/renderer.
+- [ ] **Docs:** add a `docs/`-style feature reference for the MyST theme mirroring the
+      book-theme's `docs/user/*` set, so downstream lecture maintainers have parity
+      documentation.
+
+**Effort:** S–M. **Risk:** low. **Deps:** none.
+
+---
+
+## Sequencing & dependencies
+
+```
+Phase 0  (hygiene/deploy + preview harness)  ── prerequisite for everything
+   │
+   ├─▶ Phase 1  Git history in headers      ⭐ highest value, has an upstream plugin
+   ├─▶ Phase 2  Launch parity (Binder/Thebe)
+   ├─▶ Phase 3  Code highlight + colour schemes  (needs visual preview)
+   ├─▶ Phase 4  i18n (language switcher) ──▶ Phase 5  RTL  (commonly shipped together)
+   └─▶ Phase 6  Meta/SEO + stderr + docs
+```
+
+Suggested order: **0 → 1 → 2 → 3 → (4 → 5) → 6**. Phases 1–6 are largely independent
+after Phase 0 and can be parallelised across contributors.
+
+## Open questions for maintainers
+
+1. **Upstream-first?** Several of these (git metadata rendering, language switcher,
+   RTL) could be contributed to `jupyter-book/myst-theme` rather than kept QuantEcon-only.
+   Which features are worth upstreaming vs forking?
+2. **Plugin home:** should the build-time git-metadata plugin (Phase 1) live in a shared
+   `quantecon-myst-plugins` repo consumed by every lecture repo, or per-repo?
+3. **Compute model:** how much of the launch story moves to in-page Thebe vs external
+   Colab/Binder/Hub, given infra cost and the existing `.notebooks` convention?
+4. **Scope for first migration:** which lectures migrate to JB≥2 first, and which subset
+   of phases must land before that cutover (Phase 1 git-history is likely a must-have)?

--- a/PLAN.md
+++ b/PLAN.md
@@ -69,6 +69,11 @@ entire `@myst-theme` 1.x upgrade. Parity work is meaningless until what's alread
       hand-maintained; decide whether `changeset version` should keep prepending (and
       reconcile the format) or whether the changelog is now manual. Document the choice
       in `CONTRIBUTING.md`.
+- [ ] Introduce git **release tags** (`vX.Y.Z`). The release workflow currently creates
+      no tags or GitHub releases, so the `CHANGELOG.md` compare/release footer links
+      (and any future git-history tooling) have nothing to resolve to. Tag the existing
+      releases retroactively at their source commits (recorded in the bundle repo as
+      `🚀 vX.Y.Z from <sha>`) and tag going forward as part of the release step.
 - [ ] Fix naming/branding drift: reconcile the three package names (`@curvenote/quantecon-book`
       vs `@curvenote-themes/quantecon-theme` vs `template.yml` title), and the stale
       `curvenote-themes/quantecon` deploy URL in `README.md` (line ~89).
@@ -111,7 +116,7 @@ and a "full history" link.
       with the QuantEcon blue accent, dark mode, keyboard (Esc to close), and ARIA
       matching the existing toolbar components. Use Radix (already a dependency) for the
       disclosure.
-- [ ] Build commit/​history URLs from the project `github` field (reuse the `.myst`-suffix
+- [ ] Build commit/history URLs from the project `github` field (reuse the `.myst`-suffix
       handling already in `LaunchButton.tsx`).
 - [ ] Graceful no-op when the frontmatter fields are absent.
 


### PR DESCRIPTION
## Summary

Documentation-only PR with two deliverables from a deep review of the theme and a comparison against `quantecon-book-theme`, ahead of migrating the QuantEcon lectures to Jupyter Book ≥ 2.

### 1. `CHANGELOG.md` → Keep a Changelog format
Reconstructed from git history + PRs and reformatted to match `quantecon-book-theme` (Keep a Changelog + SemVer):

- **`[Unreleased]`** section capturing the post-1.1.1 work that is in `main` but **not yet deployed** to `QuantEcon/quantecon-theme` (still v1.1.1): `@myst-theme` 0.14→1.1.2 (#30), Remix 1.17→1.19 (#29), Node `>=18` + CI + a11y fixes (#31, #32), security overrides. **Proposed release: 1.2.0.**
- Backfilled `1.0.0`→`1.1.1` with grouped `Added/Changed/Fixed` entries, dates, and compare links.

### 2. `PLAN.md` → phased feature-parity plan
Maps `quantecon-book-theme` v0.20.3 features against this theme and lays out **Phases 0–6**.

Headline gap (flagship Phase 1): **git history in lecture headers** ("Last changed" + changelog dropdown).

Key architectural call-out: the MyST theme is a **runtime** Remix server with no access to the git repo, so git-derived data must be injected upstream via a **MyST plugin** at `myst build` time — the theme only renders it. Each affected phase therefore has an upstream deliverable plus the theme change.

## Notes / decisions for review
- **Changesets interaction:** `release.yml` uses Changesets, which prepends to `CHANGELOG.md` in its own format. This hand-maintained Keep a Changelog file will need a decision (reconcile formats, or move the changelog to manual). Tracked as a Phase 0 item.
- This is **docs-only** — no code or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)