### PR TITLE
docs: Phase 0 — modernise the theme release & distribution setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> Proposed release: **1.2.0**. This is the substantial `@myst-theme` 0.14 → 1.x
-> upgrade plus a technical-review pass. The currently deployed bundle
-> (`QuantEcon/quantecon-theme`) is still **v1.1.1** and predates all of the
-> changes below — a `make deploy` is required to ship them.
+> Proposed release: **2.0.0** (major). This is the substantial `@myst-theme` 0.14 → 1.x
+> upgrade plus a technical-review pass. It is a **major** bump because it carries
+> backwards-incompatible changes for consumers: `@myst-theme` v1.0.0's new notebook
+> output-node AST (content built with an older `mystmd` may not render correctly) and a
+> raised runtime requirement (Node `>=14` → `>=18`). The currently deployed bundle
+> (`QuantEcon/quantecon-theme`) is still **v1.1.1** and predates all of the changes below
+> — a `make deploy` is required to ship them.
 
 ### Changed
 - Upgrade all `@myst-theme/*` packages from `0.14.x` to `1.1.2`, and `myst-common`/`myst-config` to `1.8.1`, aligning with the upstream [`myst-theme/book`](https://github.com/jupyter-book/myst-theme/tree/main/themes/book) template ([#30](https://github.com/QuantEcon/quantecon-theme-src/pull/30)). **Upstream breaking change:** `@myst-theme` v1.0.0 introduced a new AST structure for notebook output nodes ([jupyter-book/myst-theme#571](https://github.com/jupyter-book/myst-theme/pull/571)).

--- a/PLAN.md
+++ b/PLAN.md
@@ -110,21 +110,24 @@ upstream is heading.
 - [ ] Make `vX.Y.Z` **tags** the release trigger; tag existing releases retroactively at
       their source commits (recorded in the old build repo as `🚀 vX.Y.Z from <sha>`) so the
       `CHANGELOG.md` footer compare/release links resolve.
-- [ ] Resolve the Changesets ↔ Keep-a-Changelog tension, now that release = tag: either
-      **(a)** drop Changesets and bump/tag manually with the hand-maintained Keep a Changelog
-      (simplest for one theme — recommended), or **(b)** keep Changesets for the version bump
-      + release automation but stop it owning `CHANGELOG.md` (`"changelog": false` in
-      `.changeset/config.json`). Document the choice in `CONTRIBUTING.md`.
+- [ ] **Versioning = manual Keep a Changelog + git tags (decided — Changesets dropped).**
+      Remove `.changeset/`, rewrite `release.yml` as the tag-triggered build/release workflow,
+      and **document** the bump → changelog → tag process in `CONTRIBUTING.md`. (Rationale:
+      single non-npm artifact + small team, so Changesets' monorepo/npm payoffs don't apply
+      and its generated changelog clashes with our curated one; also matches every other
+      QuantEcon repo. "Manual" = version + changelog + tag only — build → zip → Release stays
+      automated by the tag trigger.)
 - [ ] Fold the `template.yml` `version` bump (stale at `1.0.0`) into the release step so it
       can no longer drift from `package.json`.
 
-**Cut 1.2.0 (first release on the new flow):**
-- [ ] Bump `package.json` to **1.2.0** (the `@myst-theme` 1.1.2 upgrade + technical-review
-      fixes), tag `v1.2.0`, and let the pipeline publish the release zip — moving consumers
-      off v1.1.1 at last.
-- [ ] *Sequencing:* if unsticking v1.1.1 is urgent, a one-off `make deploy` could ship 1.2.0
-      to the old build repo first — but that's throwaway since the repo is being retired.
-      Recommended: land the pipeline first and make 1.2.0 its first release.
+**Cut 1.2.0 (quick deploy now, then re-release on the new flow):**
+- [ ] **Now (decided — quick deploy first):** bump `package.json` to **1.2.0** (the
+      `@myst-theme` 1.1.2 upgrade + technical-review fixes) and run the existing `make deploy`
+      to the old build repo to get consumers off v1.1.1 **today**. This interim deploy is
+      throwaway (the build repo is being retired) — accepted for speed.
+- [ ] **After the pipeline lands:** re-publish `v1.2.0` (or the next version if changes have
+      accrued) as the first release through the new tag-triggered flow on the renamed repo,
+      then retire `make deploy`.
 
 **Consumer migration (once `v1.2.0` is published on the new flow):**
 - [ ] Repoint the **only current consumer**, `QuantEcon/lecture-wasm`
@@ -154,10 +157,12 @@ upstream is heading.
       uses `quantecon-book-theme-fixtures` + Playwright + Netlify previews — a lighter MyST
       equivalent would de-risk every later phase).
 
-**Open decisions:** (1) Changesets vs. manual versioning; (2) consumer URL policy — pinned
-`…/releases/download/vX.Y.Z/quantecon-theme.zip` per lecture (reproducible — recommended) vs.
-rolling `…/releases/latest/download/…` (one stable URL, no pinning); (3) sequencing of the
-1.2.0 cut.
+**Decisions (resolved):** (1) **versioning** — manual Keep a Changelog + git tags (Changesets
+dropped); (2) **consumer URL** — pinned per-lecture tag URLs
+(`…/releases/download/vX.Y.Z/quantecon-theme.zip`); (3) **1.2.0** — quick `make deploy` now,
+then re-release via the new pipeline; (4) **execution split** — the maintainer performs the
+repo rename + archiving, release tags and GitHub Releases are created via `gh` as a separate
+step, and all code/workflow/docs land as PRs first.
 
 **Effort:** M (pipeline + rename + consumer migration). **Risk:** low–medium (one-time
 release-flow change; upstream reference implementation exists). **Deps:** none — best done

--- a/PLAN.md
+++ b/PLAN.md
@@ -120,23 +120,23 @@ upstream is heading.
 - [ ] Fold the `template.yml` `version` bump (stale at `1.0.0`) into the release step so it
       can no longer drift from `package.json`.
 
-**Cut 1.2.0 (quick deploy now, then re-release on the new flow):**
-- [ ] **Now (decided — quick deploy first):** bump `package.json` to **1.2.0** (the
+**Cut 2.0.0 (quick deploy now, then re-release on the new flow):**
+- [ ] **Now (decided — quick deploy first):** bump `package.json` to **2.0.0** (the
       `@myst-theme` 1.1.2 upgrade + technical-review fixes) and run the existing `make deploy`
       to the old build repo to get consumers off v1.1.1 **today**. This interim deploy is
       throwaway (the build repo is being retired) — accepted for speed.
-- [ ] **After the pipeline lands:** re-publish `v1.2.0` (or the next version if changes have
+- [ ] **After the pipeline lands:** re-publish `v2.0.0` (or the next version if changes have
       accrued) as the first release through the new tag-triggered flow on the renamed repo,
       then retire `make deploy`.
 
-**Consumer migration (once `v1.2.0` is published on the new flow):**
+**Consumer migration (once `v2.0.0` is published on the new flow):**
 - [ ] Repoint the **only current consumer**, `QuantEcon/lecture-wasm`
       ([`lectures/myst.yml:120`](https://github.com/QuantEcon/lecture-wasm/blob/main/lectures/myst.yml#L120)),
       from `…/quantecon-theme/archive/refs/heads/main.zip` to the new pinned release URL
-      (`…/quantecon-theme.mystmd/releases/download/v1.2.0/quantecon-theme.zip`); verify
+      (`…/quantecon-theme.mystmd/releases/download/v2.0.0/quantecon-theme.zip`); verify
       `myst start` / `myst build --html` renders it.
 - [ ] **Order matters** — migrate the consumer *before* archiving the old build repo:
-      land pipeline → publish `v1.2.0` → repoint `lecture-wasm` → then archive
+      land pipeline → publish `v2.0.0` → repoint `lecture-wasm` → then archive
       `QuantEcon/quantecon-theme`.
 - [ ] The flagship lecture repos (`lecture-python.myst`, `lecture-julia.myst`,
       `lecture-datascience.myst`, `lecture-python-advanced.myst`, …) still use the Sphinx
@@ -159,7 +159,7 @@ upstream is heading.
 
 **Decisions (resolved):** (1) **versioning** — manual Keep a Changelog + git tags (Changesets
 dropped); (2) **consumer URL** — pinned per-lecture tag URLs
-(`…/releases/download/vX.Y.Z/quantecon-theme.zip`); (3) **1.2.0** — quick `make deploy` now,
+(`…/releases/download/vX.Y.Z/quantecon-theme.zip`); (3) **2.0.0** — quick `make deploy` now,
 then re-release via the new pipeline; (4) **execution split** — the maintainer performs the
 repo rename + archiving, release tags and GitHub Releases are created via `gh` as a separate
 step, and all code/workflow/docs land as PRs first.

--- a/PLAN.md
+++ b/PLAN.md
@@ -56,35 +56,95 @@ Derived from `quantecon-book-theme` v0.20.3 (see its `README.md`, `docs/user/*`,
 
 ---
 
-## Phase 0 — Release & deploy hygiene (prerequisite groundwork)
+## Phase 0 — Modernise the release & distribution setup (prerequisite groundwork)
 
 **Why first:** the deployed bundle is stuck at v1.1.1 (June 2025) and predates the
-entire `@myst-theme` 1.x upgrade. Parity work is meaningless until what's already in
-`main` is shipped and the dev/release loop is trustworthy.
+entire `@myst-theme` 1.x upgrade. Parity work is meaningless until what's in `main` is
+shipped *and* the release loop is trustworthy. This also uses the pre-cutover window —
+while ~no lecture references the theme yet — to fix the repo architecture cheaply.
 
-- [ ] Cut **1.2.0** (the `@myst-theme` 1.1.2 upgrade + technical-review fixes) — add a
-      changeset, bump `package.json`, sync `template.yml` `version` (currently stale at
-      `1.0.0`), then `make deploy` to refresh `QuantEcon/quantecon-theme`.
-- [ ] Resolve the Changesets ↔ Keep-a-Changelog tension: the new `CHANGELOG.md` is
-      hand-maintained; decide whether `changeset version` should keep prepending (and
-      reconcile the format) or whether the changelog is now manual. Document the choice
-      in `CONTRIBUTING.md`.
-- [ ] Introduce git **release tags** (`vX.Y.Z`). The release workflow currently creates
-      no tags or GitHub releases, so the `CHANGELOG.md` compare/release footer links
-      (and any future git-history tooling) have nothing to resolve to. Tag the existing
-      releases retroactively at their source commits (recorded in the bundle repo as
-      `🚀 vX.Y.Z from <sha>`) and tag going forward as part of the release step.
-- [ ] Fix naming/branding drift: reconcile the three package names (`@curvenote/quantecon-book`
-      vs `@curvenote-themes/quantecon-theme` vs `template.yml` title), and the stale
-      `curvenote-themes/quantecon` deploy URL in `README.md` (line ~89).
-- [ ] De-duplicate the two "Development" sections in `README.md`.
+**Decision — collapse to a single repo that distributes GitHub Release zips.** Today the
+theme is a two-repo split: source here is built by `make deploy` and pushed to a separate
+build repo (`QuantEcon/quantecon-theme`), whose `main`-branch zip lectures download. That
+split is inherited from upstream (`jupyter-book/myst-theme` → `myst-templates/book-theme`),
+where it exists because upstream is a *monorepo producing many products* (npm packages +
+the book & article themes) feeding a *named public registry* — **neither applies to us**
+(one theme, consumed by direct URL). Upstream is itself moving off it: their
+`theme-assets.yml` ships built theme zips as **GitHub Release assets** "rather than pushing
+to the myst-templates/*-theme repos … a step toward using GitHub releases instead"
+(jupyter-book/myst-enhancement-proposals#34). So a single repo + release zips tracks where
+upstream is heading.
+
+**Target architecture:**
+- **One repo**, renamed **`quantecon-theme.mystmd`** (the `.mystmd` suffix marks it as
+  `mystmd` tooling/renderer, distinct from content. Note: we deliberately do *not* reuse
+  the lectures' `.myst` suffix — that was a transitional RST→MyST marker now being retired
+  org-wide.)
+- Each release is a `vX.Y.Z` **git tag** + **GitHub Release** with a built **theme zip**
+  attached.
+- Lectures set `site.template` to a **direct GitHub zip URL** for a pinned release.
+- **Deliberate simplification (the caveat):** because lectures consume a *direct URL*, we
+  do **not** need the MyST template **registry** or any `myst-cli` template-resolution
+  support — those are exactly the parts of the upstream setup we skip. Build a zip, attach
+  it to a release, point the URL at it.
+
+**Repo consolidation & rename:**
+- [ ] Rename `quantecon-theme-src` → **`quantecon-theme.mystmd`** (GitHub 301-redirects the
+      old URLs; update the local `origin` remote).
+- [ ] Once releases are live, **archive** the old build repo `QuantEcon/quantecon-theme`
+      with a README note pointing to the new repo + release assets; do not reuse the name.
+- [ ] Retire the `make deploy` / `build-theme` / `deploy-theme` Makefile targets (replaced
+      by the release workflow); keep a local `make build-zip` for testing the artifact.
+
+**Release pipeline (adapt upstream `theme-assets.yml`):**
+- [ ] Add a workflow that, on a `vX.Y.Z` tag, builds (`npm run prod:build`), assembles the
+      bundle (`build/ public/ template.yml server.js package.json` with `template`→name and
+      `VERSION` substituted, plus `package-lock.json`, **excluding** `node_modules`), zips it,
+      and attaches it to the GitHub Release for that tag. Upstream's `theme-assets.yml` is a
+      near-verbatim reference — drop its `for THEME in book article` loop (one theme).
+- [ ] Verify `myst start` resolves `site.template: <release-asset-url>` once (a release zip
+      is just an HTTPS zip — the same mechanism today's `heads/main.zip` uses — so low risk).
+
+**Versioning & changelog:**
+- [ ] Make `vX.Y.Z` **tags** the release trigger; tag existing releases retroactively at
+      their source commits (recorded in the old build repo as `🚀 vX.Y.Z from <sha>`) so the
+      `CHANGELOG.md` footer compare/release links resolve.
+- [ ] Resolve the Changesets ↔ Keep-a-Changelog tension, now that release = tag: either
+      **(a)** drop Changesets and bump/tag manually with the hand-maintained Keep a Changelog
+      (simplest for one theme — recommended), or **(b)** keep Changesets for the version bump
+      + release automation but stop it owning `CHANGELOG.md` (`"changelog": false` in
+      `.changeset/config.json`). Document the choice in `CONTRIBUTING.md`.
+- [ ] Fold the `template.yml` `version` bump (stale at `1.0.0`) into the release step so it
+      can no longer drift from `package.json`.
+
+**Cut 1.2.0 (first release on the new flow):**
+- [ ] Bump `package.json` to **1.2.0** (the `@myst-theme` 1.1.2 upgrade + technical-review
+      fixes), tag `v1.2.0`, and let the pipeline publish the release zip — moving consumers
+      off v1.1.1 at last.
+- [ ] *Sequencing:* if unsticking v1.1.1 is urgent, a one-off `make deploy` could ship 1.2.0
+      to the old build repo first — but that's throwaway since the repo is being retired.
+      Recommended: land the pipeline first and make 1.2.0 its first release.
+
+**Hygiene carried over:**
+- [ ] Fix naming/branding drift: reconcile the package name (`@curvenote/quantecon-book` vs
+      `@curvenote-themes/quantecon-theme`) and `template.yml` `title`/`source` against the new
+      repo name.
+- [ ] De-duplicate the two "Development" sections in `README.md` and update the Usage URL to
+      the pinned-release form.
 - [ ] Triage the ~20 open Dependabot PRs; schedule the Remix v2 migration ([#28]) that
       unblocks the remaining `npm audit` findings.
-- [ ] Stand up a **visual preview / smoke test** against a real lecture repo (the
-      book-theme uses `quantecon-book-theme-fixtures` + Playwright + Netlify previews —
-      a lighter MyST equivalent would de-risk every subsequent phase).
+- [ ] Stand up a **visual preview / smoke test** against a real lecture repo (the book-theme
+      uses `quantecon-book-theme-fixtures` + Playwright + Netlify previews — a lighter MyST
+      equivalent would de-risk every later phase).
 
-**Effort:** S–M. **Risk:** low. **Deps:** none.
+**Open decisions:** (1) Changesets vs. manual versioning; (2) consumer URL policy — pinned
+`…/releases/download/vX.Y.Z/quantecon-theme.zip` per lecture (reproducible — recommended) vs.
+rolling `…/releases/latest/download/…` (one stable URL, no pinning); (3) sequencing of the
+1.2.0 cut.
+
+**Effort:** M (pipeline + rename + consumer migration). **Risk:** low–medium (one-time
+release-flow change; upstream reference implementation exists). **Deps:** none — best done
+now, pre-cutover, while nothing points at the theme.
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -104,7 +104,7 @@ upstream is heading.
       and attaches it to the GitHub Release for that tag. Upstream's `theme-assets.yml` is a
       near-verbatim reference — drop its `for THEME in book article` loop (one theme).
 - [ ] Verify `myst start` resolves `site.template: <release-asset-url>` once (a release zip
-      is just an HTTPS zip — the same mechanism today's `heads/main.zip` uses — so low risk).
+      is just an HTTPS zip — the same mechanism today's `archive/refs/heads/main.zip` uses — so low risk).
 
 **Versioning & changelog:**
 - [ ] Make `vX.Y.Z` **tags** the release trigger; tag existing releases retroactively at
@@ -122,9 +122,10 @@ upstream is heading.
 
 **Cut 2.0.0 (quick deploy now, then re-release on the new flow):**
 - [ ] **Now (decided — quick deploy first):** bump `package.json` to **2.0.0** (the
-      `@myst-theme` 1.1.2 upgrade + technical-review fixes) and run the existing `make deploy`
-      to the old build repo to get consumers off v1.1.1 **today**. This interim deploy is
-      throwaway (the build repo is being retired) — accepted for speed.
+      `@myst-theme` 1.3.0 upgrade, Node 24 toolchain, consolidated dependency/security
+      updates, and technical-review fixes — all now merged to `main`) and run the existing
+      `make deploy` to the old build repo to get consumers off v1.1.1 **today**. This interim
+      deploy is throwaway (the build repo is being retired) — accepted for speed.
 - [ ] **After the pipeline lands:** re-publish `v2.0.0` (or the next version if changes have
       accrued) as the first release through the new tag-triggered flow on the renamed repo,
       then retire `make deploy`.
@@ -151,8 +152,9 @@ upstream is heading.
       repo name.
 - [ ] De-duplicate the two "Development" sections in `README.md` and update the Usage URL to
       the pinned-release form.
-- [ ] Triage the ~20 open Dependabot PRs; schedule the Remix v2 migration ([#28]) that
-      unblocks the remaining `npm audit` findings.
+- [x] Triaged & consolidated the ~20 Dependabot PRs into a single lockfile refresh
+      ([#55](https://github.com/QuantEcon/quantecon-theme-src/pull/55)–58; `npm audit`
+      68 → 45). The remaining findings need the Remix v2 migration ([#28]) — still to schedule.
 - [ ] Stand up a **visual preview / smoke test** against a real lecture repo (the book-theme
       uses `quantecon-book-theme-fixtures` + Playwright + Netlify previews — a lighter MyST
       equivalent would de-risk every later phase).
@@ -161,12 +163,12 @@ upstream is heading.
 dropped); (2) **consumer URL** — pinned per-lecture tag URLs
 (`…/releases/download/vX.Y.Z/quantecon-theme.zip`); (3) **2.0.0** — quick `make deploy` now,
 then re-release via the new pipeline; (4) **execution split** — the maintainer performs the
-repo rename + archiving, release tags and GitHub Releases are created via `gh` as a separate
-step, and all code/workflow/docs land as PRs first.
+repo rename + archiving and pushes the `vX.Y.Z` tag via `gh`; the tag-triggered workflow then
+creates the GitHub Release and uploads the zip asset; all code/workflow/docs land as PRs first.
 
 **Effort:** M (pipeline + rename + consumer migration). **Risk:** low–medium (one-time
 release-flow change; upstream reference implementation exists). **Deps:** none — best done
-now, pre-cutover, while nothing points at the theme.
+now, pre-cutover, while only `lecture-wasm` points at the theme.
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -61,7 +61,8 @@ Derived from `quantecon-book-theme` v0.20.3 (see its `README.md`, `docs/user/*`,
 **Why first:** the deployed bundle is stuck at v1.1.1 (June 2025) and predates the
 entire `@myst-theme` 1.x upgrade. Parity work is meaningless until what's in `main` is
 shipped *and* the release loop is trustworthy. This also uses the pre-cutover window —
-while ~no lecture references the theme yet — to fix the repo architecture cheaply.
+while the theme has just one consumer (`lecture-wasm`; see the migration checklist below) —
+to fix the repo architecture cheaply.
 
 **Decision — collapse to a single repo that distributes GitHub Release zips.** Today the
 theme is a two-repo split: source here is built by `make deploy` and pushed to a separate
@@ -124,6 +125,22 @@ upstream is heading.
 - [ ] *Sequencing:* if unsticking v1.1.1 is urgent, a one-off `make deploy` could ship 1.2.0
       to the old build repo first — but that's throwaway since the repo is being retired.
       Recommended: land the pipeline first and make 1.2.0 its first release.
+
+**Consumer migration (once `v1.2.0` is published on the new flow):**
+- [ ] Repoint the **only current consumer**, `QuantEcon/lecture-wasm`
+      ([`lectures/myst.yml:120`](https://github.com/QuantEcon/lecture-wasm/blob/main/lectures/myst.yml#L120)),
+      from `…/quantecon-theme/archive/refs/heads/main.zip` to the new pinned release URL
+      (`…/quantecon-theme.mystmd/releases/download/v1.2.0/quantecon-theme.zip`); verify
+      `myst start` / `myst build --html` renders it.
+- [ ] **Order matters** — migrate the consumer *before* archiving the old build repo:
+      land pipeline → publish `v1.2.0` → repoint `lecture-wasm` → then archive
+      `QuantEcon/quantecon-theme`.
+- [ ] The flagship lecture repos (`lecture-python.myst`, `lecture-julia.myst`,
+      `lecture-datascience.myst`, `lecture-python-advanced.myst`, …) still use the Sphinx
+      `quantecon-book-theme` and are **not** consumers yet — each gets repointed as it cuts
+      over to MyST/JB≥2, not in this phase.
+- [ ] *(FYI, no action)* `QuantEcon/workflow-backups` only carries the repo-name glob
+      `quantecon-.*`, which already matches the new name.
 
 **Hygiene carried over:**
 - [ ] Fix naming/branding drift: reconcile the package name (`@curvenote/quantecon-book` vs


### PR DESCRIPTION
Docs-only. Rewrites **Phase 0** of `PLAN.md` from "deploy hygiene" into a concrete plan to modernise how the theme is released and distributed, and records the decisions agreed during review. Follows #53.

## What changed
- **Decision — collapse to a single repo distributing GitHub Release zips.** The current two-repo source/build split is inherited from upstream (`jupyter-book/myst-theme` → `myst-templates/book-theme`), which only needs it because it's a *monorepo of many npm packages + themes* feeding a *named registry* — neither applies here (one theme, consumed by a direct URL). Upstream is itself moving to release-zip assets ([myst-enhancement-proposals#34](https://github.com/jupyter-book/myst-enhancement-proposals/issues/34)).
- **Target architecture:** rename to `quantecon-theme.mystmd` (org `project.tool` suffix style — `QuantEcon.py`/`.jl`, `Bookshelf.theme`); `vX.Y.Z` tag + GitHub Release + theme zip per version; lectures pin a direct zip URL. No template registry / `myst-cli` resolution needed — direct GitHub links only.
- **Consumer-migration checklist:** an org-wide search found exactly **one** current consumer, `lecture-wasm`. Checklist repoints it with explicit ordering (pipeline → publish v1.2.0 → repoint consumer → archive old build repo) so the live consumer never breaks. Flagship lecture repos are still on the Sphinx theme and migrate per-repo at MyST cutover.

## Decisions recorded
1. **Versioning** — manual Keep a Changelog + git tags (drop Changesets; it's a single non-npm artifact and matches every other QuantEcon repo). Build → zip → Release stays automated by the tag trigger.
2. **Consumer URL** — pinned per-lecture tag URLs.
3. **1.2.0** — quick `make deploy` now to unstick v1.1.1, then re-release via the new pipeline.
4. **Execution split** — maintainer renames/archives the repos; tags & releases via `gh`; code/workflow/docs as PRs first.

No code or workflow changes in this PR — those land as follow-ups per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)