### PR TITLE
fix: wrap page tree in BannerStateProvider (unbreaks @myst-theme 1.x rendering)

### DIFF
--- a/app/components/NavigationAndArticleWrapper.tsx
+++ b/app/components/NavigationAndArticleWrapper.tsx
@@ -1,5 +1,10 @@
 import { useSidebarHeight } from '@myst-theme/site';
-import { TabStateProvider, UiStateProvider, useThemeTop } from '@myst-theme/providers';
+import {
+  BannerStateProvider,
+  TabStateProvider,
+  UiStateProvider,
+  useThemeTop,
+} from '@myst-theme/providers';
 import { Toolbar } from './toolbar/Toolbar';
 import { ContentsSidebar } from './ContentsSidebar';
 
@@ -40,12 +45,14 @@ export function NavigationAndArticleWrapper({
 }) {
   return (
     <UiStateProvider>
-      <NavigationAndArticleWrapperInternal
-        children={children}
-        hide_toc={hide_toc}
-        hideSearch={hideSearch}
-        inset={inset}
-      />
+      <BannerStateProvider>
+        <NavigationAndArticleWrapperInternal
+          children={children}
+          hide_toc={hide_toc}
+          hideSearch={hideSearch}
+          inset={inset}
+        />
+      </BannerStateProvider>
     </UiStateProvider>
   );
 }

--- a/app/components/Page.tsx
+++ b/app/components/Page.tsx
@@ -2,12 +2,7 @@ import type { PageLoader } from '@myst-theme/common';
 import { useOutlineHeight } from '@myst-theme/site';
 import { useLoaderData } from '@remix-run/react';
 import type { SiteManifest } from 'myst-config';
-import {
-  useBaseurl,
-  useSiteManifest,
-  ProjectProvider,
-  BannerStateProvider,
-} from '@myst-theme/providers';
+import { useBaseurl, useSiteManifest, ProjectProvider } from '@myst-theme/providers';
 import { ComputeOptionsProvider, ThebeLoaderAndServer } from '@myst-theme/jupyter';
 import { PageContent } from '~/components/PageContent';
 import type { TemplateOptions } from '~/types';
@@ -32,27 +27,25 @@ export function Page() {
   };
   return (
     <div className="relative bg-white dark:bg-qepage-dark">
-      <BannerStateProvider>
-        <ProjectProvider project={data.project}>
-          <PageProvider page={data.page}>
-            <NavigationAndArticleWrapper hide_toc={hide_toc} hideSearch={hide_search}>
-              <ComputeOptionsProvider
-                features={{
-                  notebookCompute: true,
-                  figureCompute: true,
-                  launchBinder: false,
-                }}
-              >
-                <ThebeLoaderAndServer baseurl={baseurl}>
-                  <main className="pt-[72px] px-2" ref={container}>
-                    <PageContent article={data.page} />
-                  </main>
-                </ThebeLoaderAndServer>
-              </ComputeOptionsProvider>
-            </NavigationAndArticleWrapper>
-          </PageProvider>
-        </ProjectProvider>
-      </BannerStateProvider>
+      <ProjectProvider project={data.project}>
+        <PageProvider page={data.page}>
+          <NavigationAndArticleWrapper hide_toc={hide_toc} hideSearch={hide_search}>
+            <ComputeOptionsProvider
+              features={{
+                notebookCompute: true,
+                figureCompute: true,
+                launchBinder: false,
+              }}
+            >
+              <ThebeLoaderAndServer baseurl={baseurl}>
+                <main className="pt-[72px] px-2" ref={container}>
+                  <PageContent article={data.page} />
+                </main>
+              </ThebeLoaderAndServer>
+            </ComputeOptionsProvider>
+          </NavigationAndArticleWrapper>
+        </PageProvider>
+      </ProjectProvider>
     </div>
   );
 }

--- a/app/components/Page.tsx
+++ b/app/components/Page.tsx
@@ -2,7 +2,12 @@ import type { PageLoader } from '@myst-theme/common';
 import { useOutlineHeight } from '@myst-theme/site';
 import { useLoaderData } from '@remix-run/react';
 import type { SiteManifest } from 'myst-config';
-import { useBaseurl, useSiteManifest, ProjectProvider } from '@myst-theme/providers';
+import {
+  useBaseurl,
+  useSiteManifest,
+  ProjectProvider,
+  BannerStateProvider,
+} from '@myst-theme/providers';
 import { ComputeOptionsProvider, ThebeLoaderAndServer } from '@myst-theme/jupyter';
 import { PageContent } from '~/components/PageContent';
 import type { TemplateOptions } from '~/types';
@@ -27,25 +32,27 @@ export function Page() {
   };
   return (
     <div className="relative bg-white dark:bg-qepage-dark">
-      <ProjectProvider project={data.project}>
-        <PageProvider page={data.page}>
-          <NavigationAndArticleWrapper hide_toc={hide_toc} hideSearch={hide_search}>
-            <ComputeOptionsProvider
-              features={{
-                notebookCompute: true,
-                figureCompute: true,
-                launchBinder: false,
-              }}
-            >
-              <ThebeLoaderAndServer baseurl={baseurl}>
-                <main className="pt-[72px] px-2" ref={container}>
-                  <PageContent article={data.page} />
-                </main>
-              </ThebeLoaderAndServer>
-            </ComputeOptionsProvider>
-          </NavigationAndArticleWrapper>
-        </PageProvider>
-      </ProjectProvider>
+      <BannerStateProvider>
+        <ProjectProvider project={data.project}>
+          <PageProvider page={data.page}>
+            <NavigationAndArticleWrapper hide_toc={hide_toc} hideSearch={hide_search}>
+              <ComputeOptionsProvider
+                features={{
+                  notebookCompute: true,
+                  figureCompute: true,
+                  launchBinder: false,
+                }}
+              >
+                <ThebeLoaderAndServer baseurl={baseurl}>
+                  <main className="pt-[72px] px-2" ref={container}>
+                    <PageContent article={data.page} />
+                  </main>
+                </ThebeLoaderAndServer>
+              </ComputeOptionsProvider>
+            </NavigationAndArticleWrapper>
+          </PageProvider>
+        </ProjectProvider>
+      </BannerStateProvider>
     </div>
   );
 }


### PR DESCRIPTION
**2.0.0 deploy blocker.** `@myst-theme` 1.x moved banner visibility/height into a React context (`BannerStateProvider`); a child component calls `useBannerState()` during SSR. Our custom [app/components/Page.tsx](app/components/Page.tsx) provider stack didn't include it, so **every page threw `useBannerState must be used from within BannerStateProvider` → HTTP 500**.

Why it slipped through:
- It's a **runtime/SSR** error — `npm run compile` and `npm run prod:build` both pass.
- It had **never rendered**: the deployed bundle is still v1.1.1 (`@myst-theme` 0.14), so the whole 0.14→1.x upgrade (#30, #59) sat in `main` green but unexecuted.

## Fix
Wrap the page tree in `BannerStateProvider` (from `@myst-theme/providers`), mirroring upstream's page route.

## Validation (via the visual harness, #60)
| | before | after |
|---|---|---|
| `/`, `/features`, `/notebook` | **500** | **200** ✓ |
| notebook stream/error outputs | (crash) | render ✓ |
| diff vs v1.1.1 baselines | — | modest **2–4%** of pixels (expected 0.14→1.3.0 styling) |

This unblocks the 2.0.0 cut. Recommend landing **#60 (harness)** and this together; after 2.0.0 is accepted, re-baseline the snapshots to 2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)