### PR TITLE
fix: keep article body in the centered content column

### DIFF
--- a/app/components/PageContent.tsx
+++ b/app/components/PageContent.tsx
@@ -79,7 +79,7 @@ export const PageContent = React.memo(function ({ article }: { article: PageLoad
                 hideKeywords
               />
               <MyST
-                className="col-screen prose-qetext-light dark:prose-qetext-dark"
+                className="prose-qetext-light dark:prose-qetext-dark"
                 ast={tree as GenericParent}
               />
               <BackmatterParts containerClassName="col-body" parts={parts} />


### PR DESCRIPTION
## Problem
Under the `@myst-theme` 0.14 → 1.x upgrade, article body content rendered **full-bleed / flush-left** (no centered content column, and the right-hand "On this page" TOC margin was swallowed). The page header/H1 stayed in the column but the body escaped it.

## Root cause
[`PageContent.tsx`](app/components/PageContent.tsx) wraps the body in `col-screen` (full-bleed). Our `styles/app.css` centers grid children via `.simple-center-grid > * { @apply col-body }` in `@layer base`, but `@myst-theme/styles` 1.x emits `.col-screen { grid-column: screen }` in a later cascade layer — so `col-screen` now wins (equal specificity → source order) and forces full width. Under 0.14 the cascade resolved the other way, so this only surfaced after the 1.x upgrade (which had never been deployed).

## Fix
Drop `col-screen` so top-level blocks fall back to the centered `col-body` default (matching upstream's `myst-content-blocks` pattern). Individual blocks can still opt into wider columns via their own class.

## Verification
Rebuilt the theme and rendered the visual-regression fixture; content is back in the centered column with the right-hand outline, matching the committed v1.1.1 baseline. Reproduced and fixed on both the synthetic `features`/`notebook` fixture pages and real lecture content.

> Pairs with #63 (Remix pin) — both are needed for 2.0.0 to render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)