### PR TITLE
chore(release): prepare v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,36 +13,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > deploy commit (`🚀 vX.Y.Z from <sha>`) in the bundled repo. There are currently no
 > git tags (see Phase 0 in [`PLAN.md`](./PLAN.md)).
 
-## [Unreleased]
+## [2.0.0] - 2026-06-04
 
-> Proposed release: **2.0.0** (major). This is the substantial `@myst-theme` 0.14 → 1.x
-> upgrade plus a technical-review pass. It is a **major** bump because it carries
-> backwards-incompatible changes for consumers: `@myst-theme` v1.0.0's new notebook
-> output-node AST (content built with an older `mystmd` may not render correctly) and a
-> raised runtime requirement (Node `>=14` → `>=18`). The currently deployed bundle
-> (`QuantEcon/quantecon-theme`) is still **v1.1.1** and predates all of the changes below
-> — a `make deploy` is required to ship them.
+> Major release: the substantial `@myst-theme` 0.14 → 1.x upgrade, a technical-review
+> pass, and a modernised release/test setup (Phase 0). It is a **major** bump because
+> it carries backwards-incompatible changes for consumers: `@myst-theme` v1.0.0's new
+> notebook output-node AST (content built with an older `mystmd` may not render
+> correctly) and a raised runtime requirement (Node `>=14` → `>=20`). The previously
+> deployed bundle (`QuantEcon/quantecon-theme`) was **v1.1.1** and predates everything
+> below; a `make deploy` ships it.
+>
+> The three "Fixed" items marked **(1.x regression)** are bugs the upgrade itself
+> introduced. They never reached users — they were caught pre-release by validating the
+> build against the visual-regression harness and real `lecture-wasm` content before
+> deploying.
 
 ### Changed
 - Upgrade all `@myst-theme/*` packages from `0.14.x` to `1.3.0`, and `myst-common`/`myst-config` to `1.9.5`, tracking current upstream [`myst-theme/book`](https://github.com/jupyter-book/myst-theme/tree/main/themes/book) ([#30](https://github.com/QuantEcon/quantecon-theme-src/pull/30) brought 0.14→1.1.2; later bumped to 1.3.0 to match latest upstream). **Upstream breaking change:** `@myst-theme` v1.0.0 introduced a new AST structure for notebook output nodes ([jupyter-book/myst-theme#571](https://github.com/jupyter-book/myst-theme/pull/571)).
-- Bump all six `@remix-run/*` packages from `~1.17.0` to `~1.19.0` (still Remix v1) to resolve an `ERESOLVE` peer-dependency conflict with `@myst-theme/site` ([#29](https://github.com/QuantEcon/quantecon-theme-src/pull/29)).
 - Raise the Node engine floor from `>=14` to `>=20` (drops EOL Node 18) and move local/CI tooling to **Node 24** (`.nvmrc` + CI + release workflow), matching upstream's build; bump release-workflow actions v3 → v4 ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
 
 ### Added
+- Playwright visual-regression harness: renders a small fixture project (plain Markdown + a notebook) through a live `myst start` against a chosen theme version and snapshots each surface, so styling/markup regressions across the upgrade are caught before deploy ([#60](https://github.com/QuantEcon/quantecon-theme-src/pull/60)).
 - CI workflow (`.github/workflows/ci.yml`) running type-check (`npm run compile`) and a production build (`npm run prod:build`) on every push/PR to `main` ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
 - `CONTRIBUTING.md` documenting development setup, available scripts, project structure, commit conventions, and the release process ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
 
 ### Fixed
+- **(1.x regression)** Every page returned HTTP 500 under `@myst-theme` 1.x (`useBannerState must be used from within a BannerStateProvider`). Wrap the page tree (article **and** error page) in `BannerStateProvider` so the new `useBannerState`/`useSidebarHeight` hooks resolve ([#61](https://github.com/QuantEcon/quantecon-theme-src/pull/61)).
+- **(1.x regression)** The article body rendered full-bleed (flush-left, no centered content column, right-hand "On this page" margin swallowed). `@myst-theme` 1.x emits `.col-screen` in a later cascade layer than our base-layer centering rule, so the body's `col-screen` wrapper won; drop it so blocks fall back to the centered `col-body` default (matching upstream's `myst-content-blocks` pattern) ([#62](https://github.com/QuantEcon/quantecon-theme-src/pull/62)).
+- **(1.x regression)** Pages flashed continuously (a hard-reload loop) and the in-page "On this page" outline never rendered. Keep `@remix-run/*` pinned to `~1.17.0` (restoring the long-standing v1.0.1 pin; reverting the [#29](https://github.com/QuantEcon/quantecon-theme-src/pull/29) bump to 1.19) — Remix 1.19's client calls `window.location.reload()` whenever `window.__remixContext.url` is undefined, which it always is under the mystmd CLI's SSR. Adds `.npmrc` `legacy-peer-deps=true` and an explicit `typescript` devDependency so installs accept `@myst-theme/site`'s stricter `^1.19` peer range ([#63](https://github.com/QuantEcon/quantecon-theme-src/pull/63)).
 - `aria-label` typo (`aira-label`) in `ProjectFrontmatter.tsx` — the authors section is now exposed to screen readers ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
 - Missing React `key` prop on author `<span>` elements built in a `.reduce()` in `ProjectFrontmatter.tsx` ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
 - Swapped `SidebarToggle.tsx` ARIA labels so each matches its visible icon state ("Show"/"Hide table of contents") ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
 - TypeScript errors surfaced by the new CI: add `@types/lodash.throttle`; wrap `Buffer` in `new Uint8Array(...)` for the `Response` body in the `[objects.inv]` and `[favicon.ico]` routes ([#32](https://github.com/QuantEcon/quantecon-theme-src/pull/32)).
 
 ### Security
-- Reduced `npm audit` findings from **60 → 34** across [#29](https://github.com/QuantEcon/quantecon-theme-src/pull/29) and [#30](https://github.com/QuantEcon/quantecon-theme-src/pull/30): `prismjs` DOM-clobbering (GHSA-x7hr-w5r2-h6wg), five KaTeX CVEs, and the dompurify/mermaid chain. Added `overrides` for `prismjs` (`^1.30.0`) and `katex` (`^0.16.21`). The remaining findings require the Remix v2 migration ([#28](https://github.com/QuantEcon/quantecon-theme-src/issues/28)) and upstream `@myst-theme` fixes.
+- Add `overrides` for `prismjs` (`^1.30.0`, GHSA-x7hr-w5r2-h6wg DOM-clobbering) and `katex` (`^0.16.21`, five CVEs), resolving those advisories ([#29](https://github.com/QuantEcon/quantecon-theme-src/pull/29), [#30](https://github.com/QuantEcon/quantecon-theme-src/pull/30)). The remaining `npm audit` findings live in the older Remix v1 build toolchain (esbuild/webpack and friends); pinning `@remix-run/*` back to `~1.17.0` for rendering correctness (see Fixed, [#63](https://github.com/QuantEcon/quantecon-theme-src/pull/63)) keeps those present until the Remix v2 migration ([#28](https://github.com/QuantEcon/quantecon-theme-src/issues/28)).
 
 ### Dependencies
-- Numerous Dependabot updates merged, including `webpack`, `vite`, `vm2`, `tar-fs`, `lodash`/`lodash-es`, `qs`/`express`, `js-yaml`, `form-data`, `brace-expansion`, `@babel/*`, `diff`, and `minimatch`.
+- Numerous Dependabot security updates merged, including `webpack`, `vite`, `vm2`, `tar-fs`, `lodash`/`lodash-es`, `qs`/`express`, `js-yaml`, `form-data`, `brace-expansion`, `@babel/*`, `diff`, and `minimatch`.
 
 ## [1.1.1] - 2025-06-13
 > Deployed to the bundle repo on 2025-06-13. The source version-bump PR
@@ -95,7 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial version of the QuantEcon MyST theme: Remix + `@myst-theme` book theme with QuantEcon branding, toolbar (home, search, fullscreen, font scaling, dark mode, downloads, Colab/JupyterHub launch, edit-on-GitHub), content-driven site footer, and bundled brand assets.
 
-[Unreleased]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.1.1...HEAD
+[2.0.0]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.1.1...v2.0.0
 [1.1.1]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.6...v1.1.0
 [1.0.6]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.5...v1.0.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@curvenote/quantecon-book",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@curvenote/quantecon-book",
-      "version": "1.1.1",
+      "version": "2.0.0",
       "hasInstallScript": true,
       "dependencies": {
         "@myst-theme/common": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvenote/quantecon-book",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "private": true,
   "sideEffects": false,
   "scripts": {

--- a/template.yml
+++ b/template.yml
@@ -1,7 +1,7 @@
 jtex: v1
 title: QuantEcon
 description: A dedicated theme for the QuantEcon course materials
-version: 1.0.0
+version: 2.0.0
 license: MIT
 source: https://github.com/QuantEcon/quantecon-theme
 thumbnail: ./thumbnail.png


### PR DESCRIPTION
## Prepare v2.0.0

Version bump + CHANGELOG finalization for the **2.0.0** release. No code/behaviour changes.

### What's in this PR
- Bump to `2.0.0`: `package.json` + `package-lock.json` (`1.1.1 → 2.0.0`), and `template.yml` (`1.0.0 → 2.0.0` — its `version` had drifted from the package version; now aligned).
- Finalize the CHANGELOG `[2.0.0]` section (was `[Unreleased]`), with corrections:
  - **Drop the reverted #29 Remix `1.17→1.19` bump** — 2.0.0 stays on the long-standing `~1.17.0` pin (restored at v1.0.1), so there's *no net Remix change*.
  - Fix the Node floor to `>=20` (matching `engines`).
  - Add the visual-regression harness (#60) and the three pre-release fixes (#61, #62, #63).
  - Restate Security: the older Remix v1 toolchain's `npm audit` findings remain until the Remix v2 migration (#28).

### Why we're ready
2.0.0 is the `@myst-theme` 0.14 → 1.x upgrade. The three regressions the upgrade introduced are fixed and **verified on both the visual-regression fixture and real `lecture-wasm` content** — centered content column, restored "On this page" outline, and no hydration reload loop ("flashing"). None reached users; the 1.x upgrade had never been deployed.

### After merge — shipping the release (manual)
Deploy is **not** automated by merge. From `main` on **Node 24**:
```
make deploy
```
This builds the bundle and pushes a `🚀 v2.0.0 from <sha>` commit to [`QuantEcon/quantecon-theme`](https://github.com/QuantEcon/quantecon-theme). Consumers track that repo's `main.zip`, so the deploy **is** the production cutover — render-check a lecture immediately afterwards.

### Notes / follow-ups (out of scope here)
- CHANGELOG is dated **2026-06-04**, assuming deploy lands today — adjust if it slips.
- Visual-regression baselines are still **v1.1.1**; re-baseline to 2.0.0 in a fast-follow so the harness guards the new rendering.
- `release.yml` still runs the **Changesets** action (harmless now — no changeset files — but conflicts with the decided manual-CHANGELOG + `make deploy` flow). Clean up as part of Phase 0.
- CHANGELOG compare links are tag-based but the repo has **no git tags yet** (noted in the CHANGELOG header); introducing tagging is a Phase 0 task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)