### PR TITLE
fix: inline critical CSS to stop the Safari FOUC on navigation (#66)

### DIFF
--- a/.changeset/fouc-critical-css.md
+++ b/.changeset/fouc-critical-css.md
@@ -1,0 +1,7 @@
+---
+"@curvenote/quantecon-book": patch
+---
+
+Fix the Safari/WebKit flash of unstyled content (FOUC) on page navigation by inlining critical CSS in the document `<head>`.
+
+Static builds navigate via full document loads, and WebKit paints the freshly-navigated document for ~1 frame before any `<link>` stylesheet applies — showing the default serif font and a collapsed (`display: block`) layout. The inlined critical block (base font + `.simple-center-grid` layout) parses synchronously with the document, so the first paint is already styled. Every rule is wrapped in `:where(...)` so it carries zero specificity and is superseded by the real stylesheet once it loads. See QuantEcon/quantecon-theme-src#66.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,33 @@ jobs:
       - run: npm ci
       - run: npm run compile
       - run: npm run prod:build
+
+  fouc-guard:
+    name: FOUC guard (WebKit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      # The visual harness serves the fixture through a live `myst start`.
+      - name: Install mystmd CLI
+        run: npm install -g mystmd
+      # Builds the candidate theme from this branch into .deploy/quantecon-theme.
+      - name: Build theme template
+        run: make build-theme
+      - name: Install Playwright WebKit
+        run: npx playwright install --with-deps webkit
+      - name: Run FOUC guard (QuantEcon/quantecon-theme-src#66)
+        run: npm run test:fouc
+        env:
+          THEME_TEMPLATE: ${{ github.workspace }}/.deploy/quantecon-theme
+          PORT: "3111"
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: fouc-playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -32,6 +32,39 @@ export const meta: V2_MetaFunction<typeof loader> = ({ data }) => {
   });
 };
 
+/**
+ * Critical CSS — inlined in <head> to fix the Safari/WebKit FOUC on navigation
+ * (https://github.com/QuantEcon/quantecon-theme-src/issues/66).
+ *
+ * Static builds (`myst build --html`) navigate via full document loads, and
+ * WebKit paints the freshly-navigated document for ~1 frame BEFORE any <link>
+ * stylesheet applies — even the same-origin Tailwind app.css. That frame shows
+ * the default serif font and the content grid collapsed to `display: block`
+ * (i.e. the "raw HTML" flash users report). An inline <style> is parsed
+ * synchronously with the document, so it styles that very first paint with no
+ * network round-trip.
+ *
+ * Every selector is wrapped in `:where(...)` so these rules carry **zero**
+ * specificity: they take effect only while nothing else has loaded, and the
+ * real stylesheet (Tailwind preflight + @myst-theme/styles) always wins once it
+ * arrives. This keeps the inline block from overriding the live cascade despite
+ * being emitted after <Links /> in the document head.
+ *
+ * Keep the values in sync with their sources of truth:
+ *   - font stack:    tailwind.config.js  -> theme.extend.fontFamily.sans
+ *   - grid columns:  tailwind.config.js  -> theme.extend.gridTemplateColumns
+ *                    (`simple-sm` / `simple-xl`), applied by `.simple-center-grid`
+ *   - dark bg:       Tailwind `stone-900` (#1c1917), see <body> className below
+ */
+const CRITICAL_CSS = `
+:where(html){font-family:"Source Sans 3",sans-serif}
+:where(body){margin:0;background-color:#fff}
+:where(.dark body){background-color:#1c1917}
+:where(.simple-center-grid){display:grid;grid-template-columns:[screen-start] 1fr [body-start] minmax(300px,800px) [body-end] 1fr [screen-end]}
+:where(.simple-center-grid) > *{grid-column:body-start / body-end}
+@media (min-width:1280px){:where(.simple-center-grid){grid-template-columns:[screen-start] 1fr 200px 20px [body-start] 800px [body-end] 20px [margin-start] 200px [margin-end] 1fr [screen-end]}}
+`;
+
 export const links: LinksFunction = () => {
   return [
     {
@@ -97,6 +130,7 @@ export default function AppWithReload() {
         baseurl={BASE_URL}
         renderers={RENDERERS}
         top={50}
+        head={<style dangerouslySetInnerHTML={{ __html: CRITICAL_CSS }} />}
       >
         <SkipTo
           targets={[

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -54,12 +54,18 @@ export const meta: V2_MetaFunction<typeof loader> = ({ data }) => {
  *   - font stack:    tailwind.config.js  -> theme.extend.fontFamily.sans
  *   - grid columns:  tailwind.config.js  -> theme.extend.gridTemplateColumns
  *                    (`simple-sm` / `simple-xl`), applied by `.simple-center-grid`
- *   - dark bg:       Tailwind `stone-900` (#1c1917), see <body> className below
+ *   - dark bg:       matches the page <body>, which @myst-theme/site renders as
+ *                    `dark:bg-stone-900` (#1c1917) — note the <body> tag lives in
+ *                    that upstream Document, not in this file. (This is the outer
+ *                    page background; the inner content panel uses `qepage-dark`
+ *                    #222, see app/components/Page.tsx — intentionally not set here
+ *                    since these rules target <body>.)
  */
 const CRITICAL_CSS = `
 :where(html){font-family:"Source Sans 3",sans-serif}
 :where(body){margin:0;background-color:#fff}
 :where(.dark body){background-color:#1c1917}
+:where([hidden],.hidden){display:none}
 :where(.simple-center-grid){display:grid;grid-template-columns:[screen-start] 1fr [body-start] minmax(300px,800px) [body-end] 1fr [screen-end]}
 :where(.simple-center-grid) > *{grid-column:body-start / body-end}
 @media (min-width:1280px){:where(.simple-center-grid){grid-template-columns:[screen-start] 1fr 200px 20px [body-start] 800px [body-end] 20px [margin-start] 200px [margin-end] 1fr [screen-end]}}
@@ -130,6 +136,11 @@ export default function AppWithReload() {
         baseurl={BASE_URL}
         renderers={RENDERERS}
         top={50}
+        // dangerouslySetInnerHTML is required, not incidental: CRITICAL_CSS uses a
+        // child combinator (`.simple-center-grid > *`), and React escapes `>` to
+        // `&gt;` in <style> text children during SSR. Browsers don't decode entities
+        // inside <style>, so `<style>{CRITICAL_CSS}</style>` would emit an invalid
+        // selector and silently drop the body-column rule. Keep this as-is.
         head={<style dangerouslySetInnerHTML={{ __html: CRITICAL_CSS }} />}
       >
         <SkipTo

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "start": "npm run build:css && remix dev",
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots",
+    "test:fouc": "playwright test --project=webkit-fouc",
     "changeset": "changeset",
     "version": "changeset version && npm install --force"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,11 +26,24 @@ export default defineConfig({
   snapshotPathTemplate: "{testDir}/__snapshots__/{projectName}/{arg}{ext}",
   use: { baseURL, trace: "on-first-retry" },
   projects: [
+    // Visual snapshots run on Chromium (theme.spec.ts).
     {
       name: "desktop-chrome",
+      testMatch: /theme\.spec\.ts/,
       use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 800 } },
     },
-    { name: "mobile-chrome", use: { ...devices["Pixel 5"] } },
+    {
+      name: "mobile-chrome",
+      testMatch: /theme\.spec\.ts/,
+      use: { ...devices["Pixel 5"] },
+    },
+    // FOUC guard runs on WebKit only — Chromium paint-holds and can't show the
+    // flash (fouc.spec.ts, see QuantEcon/quantecon-theme-src#66).
+    {
+      name: "webkit-fouc",
+      testMatch: /fouc\.spec\.ts/,
+      use: { ...devices["Desktop Safari"] },
+    },
   ],
   webServer: {
     command: "bash tests/visual/serve.sh",

--- a/tests/visual/README.md
+++ b/tests/visual/README.md
@@ -15,7 +15,8 @@ we screenshot the same content rendered by different theme versions and diff.
 
 - Node 24 (`.nvmrc`) and the `mystmd` CLI (`myst`) on `PATH`
 - `npm ci` (installs `@playwright/test`)
-- `npx playwright install --with-deps chromium` (browser binaries)
+- `npx playwright install --with-deps chromium webkit` (browser binaries —
+  `chromium` for the visual snapshots, `webkit` for the FOUC guard below)
 
 ## Selecting the theme: `THEME_TEMPLATE`
 
@@ -52,12 +53,31 @@ THEME_TEMPLATE="$PWD/.deploy/quantecon-theme" \
 > shipped. To compare against any released bundle, point `THEME_TEMPLATE` at its
 > archive zip.
 
+## FOUC guard (WebKit)
+
+`fouc.spec.ts` guards the Safari/WebKit flash-of-unstyled-content fix
+([#66](https://github.com/QuantEcon/quantecon-theme-src/issues/66)): it aborts
+all external stylesheets so the only styling that can reach the first paint is
+the inline critical CSS in `app/root.tsx`, then asserts the layout/font are
+already correct (and a control case proves the abort really strips styling).
+It is **snapshot-free** (asserts computed `display`/`font-family`, not pixels),
+so it is robust across `myst`/CI versions. It runs on the `webkit-fouc` project
+only — Chromium paint-holds and cannot exhibit the flash — and is wired into CI
+as the `FOUC guard (WebKit)` job.
+
+```bash
+make build-theme
+THEME_TEMPLATE="$PWD/.deploy/quantecon-theme" \
+  npm run test:fouc
+```
+
 ## Files
 
 - `fixture/` — minimal MyST project (`intro.md`, `features.md`, `notebook.ipynb`)
 - `fixture/myst.yml.in` — template; `serve.sh` writes `myst.yml` from it
 - `serve.sh` — `myst start` with the chosen `THEME_TEMPLATE`
-- `theme.spec.ts` — one full-page snapshot per surface
+- `theme.spec.ts` — one full-page snapshot per surface (Chromium)
+- `fouc.spec.ts` — FOUC guard, no snapshots (WebKit)
 - `__snapshots__/` — committed baselines
 
 > The generated `fixture/myst.yml`, `fixture/_build/`, and `playwright-report/`

--- a/tests/visual/fouc.spec.ts
+++ b/tests/visual/fouc.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+/**
+ * FOUC guard (WebKit) — QuantEcon/quantecon-theme-src#66.
+ *
+ * In the static build every navigation is a full document load, and WebKit
+ * paints the fresh document *before* its external `<link>` stylesheets apply —
+ * so for ~1 frame the page renders with the default serif font and the content
+ * grid collapsed to `display: block`. The fix inlines critical CSS into `<head>`
+ * (see `app/root.tsx`), which parses synchronously and styles that first paint.
+ *
+ * This test makes the failure mode deterministic by **aborting all external
+ * stylesheets**, so the only styling that can reach the page is the inline
+ * `<style>`. If the inline critical CSS regresses, the "styled first paint"
+ * assertion below fails. The control case strips the inline block to prove the
+ * abort genuinely removes external styling (otherwise the guard would be moot).
+ *
+ * Runs in the `webkit-fouc` Playwright project only — Chromium paint-holds and
+ * cannot exhibit this flash.
+ */
+
+const PAGE = "/";
+
+async function isolateInlineCss(page: Page, { stripCritical = false } = {}) {
+  await page.route("**/*", async (route: Route) => {
+    const req = route.request();
+
+    // External stylesheets never apply -> isolates the inline critical CSS.
+    if (req.resourceType() === "stylesheet" || /\.css(\?|$)/i.test(req.url())) {
+      return route.abort();
+    }
+
+    // Control: serve the document with the inlined critical <style> removed.
+    if (req.resourceType() === "document" && stripCritical) {
+      const response = await route.fetch();
+      const body = (await response.text()).replace(
+        /<style>[^<]*:where\(\.simple-center-grid\)[^<]*<\/style>/g,
+        "<!-- critical CSS removed for control -->",
+      );
+      return route.fulfill({ response, body });
+    }
+
+    return route.continue();
+  });
+}
+
+async function firstPaintState(page: Page) {
+  await page.goto(PAGE, { waitUntil: "domcontentloaded" });
+  await page.waitForSelector(".simple-center-grid", { timeout: 5000 }).catch(() => {});
+  return page.evaluate(() => {
+    const grid = document.querySelector(".simple-center-grid");
+    const applied = Array.from(document.styleSheets).filter((sheet) => {
+      try {
+        return !!sheet.cssRules && sheet.cssRules.length > 0; // applied, not pending
+      } catch {
+        return false; // cross-origin / not yet loaded
+      }
+    });
+    return {
+      gridDisplay: grid ? getComputedStyle(grid).display : "(absent)",
+      bodyFont: getComputedStyle(document.body).fontFamily,
+      // null href == an inline <style>; any string == an external sheet that applied
+      appliedExternal: applied.some((sheet) => !!sheet.href),
+    };
+  });
+}
+
+test.describe("FOUC guard (WebKit) — inline critical CSS styles the first paint", () => {
+  test("page-as-served is styled even with external CSS unavailable", async ({ page }) => {
+    await isolateInlineCss(page);
+    const state = await firstPaintState(page);
+
+    // No external sheet applied, so anything styled below comes from inline CSS.
+    expect(state.appliedExternal).toBe(false);
+    // The two reported FOUC symptoms must be absent on first paint:
+    expect(state.gridDisplay).toBe("grid"); // grid not collapsed to block
+    expect(state.bodyFont).toMatch(/Source Sans 3/); // sans, not the serif default
+  });
+
+  test("control: removing the inline critical CSS reproduces the FOUC", async ({ page }) => {
+    await isolateInlineCss(page, { stripCritical: true });
+    const state = await firstPaintState(page);
+
+    // With no CSS at all, the page is unstyled — this proves the guard above is
+    // meaningful (the external abort really does strip styling).
+    expect(state.appliedExternal).toBe(false);
+    expect(state.gridDisplay).toBe("block");
+    expect(state.bodyFont).not.toMatch(/Source Sans 3/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the Safari/WebKit **flash of unstyled content (FOUC)** on page navigation reported in #66, by inlining a small **critical CSS** block in the document `<head>`.

### Root cause (from #66)
Static builds (`myst build --html`) navigate via **full document loads** — `@myst-theme/site` forces `reloadDocument: true` when `staticBuild` is on, so internal links are plain `<a href>`. On each navigation WebKit/Safari paints the freshly-loaded document for **~1 frame before any `<link>` stylesheet applies** — even the same-origin Tailwind `app.css`. That frame renders with the default **serif font** and the content grid collapsed to **`display: block`** (i.e. the "raw HTML that looks broken" users report). Chromium hides this via paint-holding; WebKit does not.

### Fix
Inline the genuinely-critical rules in `<head>` via the `Document` `head` prop. An inline `<style>` parses **synchronously** with the document, so it styles WebKit's very first paint with no network round-trip:

- base font stack (`Source Sans 3`, sans-serif fallback) — kills the serif flash even before the webfont loads;
- `.simple-center-grid` `display: grid` + the `simple-sm` / `simple-xl` column tracks — keeps the centered content column instead of collapsing to a full-width block;
- `margin: 0` + light/dark background — avoids the body-margin jump and a white flash in dark mode.

Every selector is wrapped in **`:where(...)`** so the rules carry **zero specificity**. They take effect only while nothing else has loaded; the real stylesheet (Tailwind preflight + `@myst-theme/styles`) always wins once it arrives — so the live cascade (including margin-column placement) is unaffected, even though the inline block is emitted after `<Links />` in the head.

### Why not the other options in #66
- **SPA navigation (#1)** — not feasible from this repo; full-document nav is forced upstream by `@myst-theme/site` (`staticBuild` → `reloadDocument: true`) and the MyST static export.
- **Self-host the 3 CDN stylesheets (#3) + katex version (#4)** — deliberately left out of this PR (would require vendoring font binaries). Per the WebKit analysis in #66 these shorten the flash but don't fix it on their own; they remain optional follow-ups.

## Maintenance note
The inlined values must stay in sync with their sources of truth — `tailwind.config.js` (`fontFamily.sans`, `gridTemplateColumns.simple-sm/-xl`) and the `stone-900` dark background. This is documented in a comment above the `CRITICAL_CSS` constant in [app/root.tsx](app/root.tsx).

## Testing
- `npm run compile` (tsc) — passes
- `npm run prod:build` — builds clean; critical CSS confirmed present in both server and client bundles
- Note: the Safari FOUC is a ~1-frame WebKit-only repro (see #66) and isn't reproducible headless; reviewers on actual Safari can confirm the flash is gone.

Addresses #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)