### PR TITLE
fix: link top-level TOC pages in the Contents sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Top-level (level-1) TOC pages now render as clickable links in the Contents sidebar when they have a slug, so flat-TOC projects are navigable; slug-less grouping titles remain plain headers ([#76](https://github.com/QuantEcon/quantecon-theme-src/pull/76)).
 - Safari/WebKit flash of unstyled content (FOUC) on page navigation: inline a zero-specificity (`:where(...)`) critical-CSS block (base font + `.simple-center-grid` layout) in the document `<head>` so the first paint is already styled before the linked stylesheet applies ([#66](https://github.com/QuantEcon/quantecon-theme-src/pull/66)).
 
 ### Security

--- a/app/components/ContentsSidebar.tsx
+++ b/app/components/ContentsSidebar.tsx
@@ -49,6 +49,8 @@ export function ContentsSidebar() {
   const project = useProjectManifest();
   const top = useThemeTop();
   const { toc } = useSidebarHeight(top);
+  const baseurl = useBaseurl();
+  const Link = useLinkProvider();
 
   if (!config) return null;
 
@@ -103,12 +105,20 @@ export function ContentsSidebar() {
                 group={headingOrGroup}
               />
             );
+          // A top-level entry with a slug is a real page (e.g. a flat TOC) and
+          // must be navigable; without one it is a pure grouping title.
           return (
             <p
               className="mt-5 mb-4 text-lg font-semibold text-qetext-light dark:text-qetext-dark"
               key={headingOrGroup.slug ?? headingOrGroup.title}
             >
-              {headingOrGroup.title}
+              {headingOrGroup.slug ? (
+                <Link to={withBaseurl(`/${slugToUrl(headingOrGroup.slug)}`, baseurl)}>
+                  {headingOrGroup.title}
+                </Link>
+              ) : (
+                headingOrGroup.title
+              )}
             </p>
           );
         })}


### PR DESCRIPTION
## Summary

Fixes #70.

In the **Contents** sidebar, top-level (level-1) TOC entries rendered as non-clickable `<p>` headers even when the entry has a slug (i.e. is a real page). For a **flat** TOC — like the visual-regression fixture (`tests/visual/fixture`) — this meant the sidebar had **zero clickable navigation**.

This PR makes the top-level branch in [`ContentsSidebar.tsx`](app/components/ContentsSidebar.tsx) render a `<Link>` when the heading has a slug, and keeps the plain header for slug-less grouping titles — so nested book TOCs (parts → chapters) are unchanged.

## Verification

- `npm run compile` — clean.
- Full visual suite against a candidate `make build-theme` bundle: **8/8 pass** (desktop + mobile snapshots, FOUC guard) with **no snapshot drift** — the sidebar is off-canvas in the captured screenshots.
- Enumerated every internal `<a href>` on the served fixture home page:

  **Before** (per #70): only the logo (`/`) and `Back to top`.

  **After:**
  ```
  <a href="/">QuantEcon Theme — Visual Fixture</a>
  <a href="/#top">Back to top</a>
  <a href="/features">Features</a>
  <a href="/notebook">Notebook outputs</a>
  ```

## Acceptance criteria (from #70)

- [x] In a flat TOC, top-level pages with a slug are clickable links in the sidebar.
- [x] Nested book TOCs unchanged: grouping titles without a slug remain non-link headers; chapters remain links.
- [x] Visual-regression fixture sidebar entries ("Features", "Notebook outputs") are clickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)