### PR TITLE
ci: tag-triggered build → zip → GitHub Release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+# Tag-triggered build → zip → GitHub Release pipeline (PLAN.md Phase 0, #71).
+#
+# Pushing a `vX.Y.Z` tag builds the theme, assembles the same bundle that
+# `make build-theme` ships (adapted from upstream jupyter-book/myst-theme's
+# `theme-assets.yml`), and publishes a GitHub Release for the tag with
+# `quantecon-theme.zip` attached. Lectures then pin a release URL:
+#   …/releases/download/vX.Y.Z/quantecon-theme.zip
+#
+# The zip contains:
+#   build/, public/                 (from `npm run prod:build`)
+#   template.yml                    (version stamped from package.json — #71)
+#   server.js, package.json, LICENSE, README.md, thumbnail.png, qe-logo.png
+#                                   (from template/, with VERSION substituted)
+#   package-lock.json               (generated; node_modules is NOT shipped)
+#   CHANGELOG.md
+#
+# Guards (both fail the release):
+#   - the tag must match `package.json` `version`
+#   - CHANGELOG.md must have a `## [X.Y.Z]` section — it becomes the release notes
+#
+# This replaces the Changesets release.yml (removed in #72). The legacy
+# `make deploy` push to QuantEcon/quantecon-theme remains only until consumers
+# are repointed to pinned release URLs (PLAN.md Phase 0 consumer migration).
+
+on:
+  push:
+    tags: ['v*.*.*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build & publish release zip
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Verify tag matches package.json version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [ "v$VERSION" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match package.json version v$VERSION — bump package.json (see CONTRIBUTING.md \"Releases\") and re-tag."
+            exit 1
+          fi
+
+      - name: Extract release notes from CHANGELOG.md
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          awk -v ver="$VERSION" '
+            index($0, "## [" ver "]") == 1 { flag = 1; next }
+            /^## /                         { flag = 0 }
+            flag
+          ' CHANGELOG.md > release-notes.md
+          if ! grep -q '[^[:space:]]' release-notes.md; then
+            echo "::error::CHANGELOG.md has no \"## [$VERSION]\" section — add the curated entry (see CONTRIBUTING.md \"Releases\") and re-tag."
+            exit 1
+          fi
+
+      - run: npm ci
+      - run: npm run compile
+      - name: Build
+        # esbuild occasionally deadlocks (QuantEcon/quantecon-theme-src — known
+        # flake); time out fast so the run can simply be retried.
+        timeout-minutes: 20
+        run: npm run prod:build
+
+      - name: Assemble theme bundle and zip
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          DIST=dist/quantecon-theme
+          mkdir -p "$DIST"
+          find template -type f -exec cp {} "$DIST" \;
+          cp -r public "$DIST/public"
+          cp -r build "$DIST/build"
+          cp CHANGELOG.md "$DIST/CHANGELOG.md"
+          # Stamp both version fields from package.json so the shipped bundle
+          # cannot drift (#71).
+          sed -i "s/VERSION/$VERSION/g" "$DIST/package.json"
+          sed -E "s/^version: .*/version: $VERSION/" template.yml > "$DIST/template.yml"
+          # Lockfile for reproducible consumer installs, without shipping node_modules.
+          (cd "$DIST" && npm install --package-lock-only)
+          (cd dist && zip -r ../quantecon-theme.zip quantecon-theme)
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release-notes.md
+          files: quantecon-theme.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Tag-triggered release pipeline (`.github/workflows/release.yml`): pushing a `vX.Y.Z` tag builds the theme, assembles the bundle (with `template.yml`'s `version` stamped from `package.json` so they cannot drift), and publishes a GitHub Release with `quantecon-theme.zip` attached, using the version's changelog section as the release notes ([#77](https://github.com/QuantEcon/quantecon-theme-src/pull/77)).
+
 ### Fixed
 - Safari/WebKit flash of unstyled content (FOUC) on page navigation: inline a zero-specificity (`:where(...)`) critical-CSS block (base font + `.simple-center-grid` layout) in the document `<head>` so the first paint is already styled before the linked stylesheet applies ([#66](https://github.com/QuantEcon/quantecon-theme-src/pull/66)).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,16 +90,24 @@ To cut a release:
 
 1. In `CHANGELOG.md`, move the `## [Unreleased]` entries under a new `## [X.Y.Z] - YYYY-MM-DD`
    heading and add the footer compare link.
-2. Bump the version in **both** `package.json` and `template.yml` (keep them in sync).
+2. Bump the version in `package.json` (e.g. `npm version X.Y.Z --no-git-tag-version`).
+   You do **not** need to bump `template.yml` — the release workflow stamps its `version`
+   from `package.json` into the published bundle, so the two cannot drift.
 3. Commit (`chore(release): prepare vX.Y.Z`) and open a PR.
 4. After merge, tag the release commit and push the tag:
    ```bash
    git tag vX.Y.Z && git push origin vX.Y.Z
    ```
+5. The tag triggers [`release.yml`](./.github/workflows/release.yml), which builds the
+   theme, zips the bundle, and publishes a **GitHub Release** for the tag with
+   `quantecon-theme.zip` attached, using the version's `CHANGELOG.md` section as the
+   release notes. The workflow **fails** if the tag does not match `package.json` or if
+   `CHANGELOG.md` has no `## [X.Y.Z]` section — fix and re-tag.
 
-> **Note:** the tag-triggered build → zip → GitHub Release pipeline is still being set up
-> (see [#71](https://github.com/QuantEcon/quantecon-theme-src/issues/71)). Until it lands,
-> the theme is shipped with `make deploy`.
+> **Note:** consumers are still being migrated to pinned release URLs
+> (see [#71](https://github.com/QuantEcon/quantecon-theme-src/issues/71) and PLAN.md
+> Phase 0). Until `lecture-wasm` is repointed, also run `make deploy` to update the
+> legacy `QuantEcon/quantecon-theme` build repo.
 
 ## Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,19 @@ To cut a release:
    theme, zips the bundle, and publishes a **GitHub Release** for the tag with
    `quantecon-theme.zip` attached, using the version's `CHANGELOG.md` section as the
    release notes. The workflow **fails** if the tag does not match `package.json` or if
-   `CHANGELOG.md` has no `## [X.Y.Z]` section — fix and re-tag.
+   `CHANGELOG.md` has no `## [X.Y.Z]` section.
+
+If a release run fails, the failed run published nothing, so recovery is safe:
+
+- **Transient build failure** (e.g. the occasional esbuild hang): no changes needed —
+  re-run the failed workflow from the Actions UI.
+- **Guard failure** (version mismatch / missing changelog section): land the fix on
+  `main` via a PR, then **move the tag** to the new commit — a pushed tag cannot simply
+  be re-pushed:
+  ```bash
+  git tag -f vX.Y.Z <new-commit-sha>
+  git push --force origin vX.Y.Z
+  ```
 
 > **Note:** consumers are still being migrated to pinned release URLs
 > (see [#71](https://github.com/QuantEcon/quantecon-theme-src/issues/71) and PLAN.md

--- a/PLAN.md
+++ b/PLAN.md
@@ -98,19 +98,24 @@ upstream is heading.
       by the release workflow); keep a local `make build-zip` for testing the artifact.
 
 **Release pipeline (adapt upstream `theme-assets.yml`):**
-- [ ] Add a workflow that, on a `vX.Y.Z` tag, builds (`npm run prod:build`), assembles the
+- [x] Add a workflow that, on a `vX.Y.Z` tag, builds (`npm run prod:build`), assembles the
       bundle (`build/ public/ template.yml server.js package.json` with `template`→name and
       `VERSION` substituted, plus `package-lock.json`, **excluding** `node_modules`), zips it,
       and attaches it to the GitHub Release for that tag. Upstream's `theme-assets.yml` is a
       near-verbatim reference — drop its `for THEME in book article` loop (one theme).
+      **Done in [#77](https://github.com/QuantEcon/quantecon-theme-src/pull/77)** —
+      `.github/workflows/release.yml`: tag-triggered, guards tag ↔ `package.json` version,
+      requires (and uses as release notes) the version's `CHANGELOG.md` section.
 - [ ] Verify `myst start` resolves `site.template: <release-asset-url>` once (a release zip
       is just an HTTPS zip — the same mechanism today's `archive/refs/heads/main.zip` uses — so low risk).
 
 **Versioning & changelog:** *(remaining work tracked in [#71](https://github.com/QuantEcon/quantecon-theme-src/issues/71))*
-- [ ] Make `vX.Y.Z` **tags** the release trigger; tag existing releases retroactively at
-      their source commits (recorded in the old build repo as `🚀 vX.Y.Z from <sha>`) so the
-      `CHANGELOG.md` footer compare/release links resolve.
-- [ ] **Versioning = manual Keep a Changelog + git tags (decided — Changesets dropped).**
+- [ ] Make `vX.Y.Z` **tags** the release trigger *(trigger wired up in
+      [#77](https://github.com/QuantEcon/quantecon-theme-src/pull/77))*; tag existing releases
+      retroactively at their source commits (recorded in the old build repo as
+      `🚀 vX.Y.Z from <sha>`) so the `CHANGELOG.md` footer compare/release links resolve
+      *(retro-tagging still TODO — maintainer pushes the tags per the execution split below)*.
+- [x] **Versioning = manual Keep a Changelog + git tags (decided — Changesets dropped).**
       Remove `.changeset/`, rewrite `release.yml` as the tag-triggered build/release workflow,
       and **document** the bump → changelog → tag process in `CONTRIBUTING.md`. (Rationale:
       single non-npm artifact + small team, so Changesets' monorepo/npm payoffs don't apply
@@ -120,11 +125,13 @@ upstream is heading.
       **Status:** done in [#72](https://github.com/QuantEcon/quantecon-theme-src/pull/72) —
       removed `.changeset/`, dropped `@changesets/cli` + the `changeset`/`version` scripts,
       migrated the pending entries into `CHANGELOG.md` `## [Unreleased]`, documented the manual
-      flow in `CONTRIBUTING.md`, and closed the stale Changesets PR #69. **Remaining:** the
-      tag-triggered `release.yml` rewrite (the build → zip → Release pipeline above).
-- [ ] Fold the `template.yml` `version` bump into the release step so it can no longer drift
-      from `package.json` (both at `2.0.0` now, kept in sync manually per `CONTRIBUTING.md`;
-      automation still TODO).
+      flow in `CONTRIBUTING.md`, and closed the stale Changesets PR #69. The tag-triggered
+      `release.yml` (the build → zip → Release pipeline above) landed in
+      [#77](https://github.com/QuantEcon/quantecon-theme-src/pull/77).
+- [x] Fold the `template.yml` `version` bump into the release step so it can no longer drift
+      from `package.json` (done in [#77](https://github.com/QuantEcon/quantecon-theme-src/pull/77):
+      the workflow stamps `template.yml`'s `version` from `package.json` into the bundle, and
+      fails if the tag doesn't match `package.json`).
 
 **Cut 2.0.0 (quick deploy now, then re-release on the new flow):**
 - [x] **Now (decided — quick deploy first):** bump `package.json` to **2.0.0** (the


### PR DESCRIPTION
## Summary

Closes #71 — the two remaining tasks: the tag-triggered `release.yml` rewrite and folding the `template.yml` version bump into the release step.

Pushing a `vX.Y.Z` tag now runs [`.github/workflows/release.yml`](.github/workflows/release.yml), which:

1. **Guards** the release: fails early if the tag ≠ `package.json` `version`, or if `CHANGELOG.md` has no `## [X.Y.Z]` section (that section becomes the release notes — keeping the curated changelog the single source).
2. **Builds** (`npm ci` → `compile` → `prod:build`, with a 20-min timeout so the known esbuild deadlock flake fails fast and can be retried).
3. **Assembles** the same bundle `make build-theme` ships: `template/` files (`server.js`, `package.json` with `VERSION` substituted, LICENSE, README, logos), `build/`, `public/`, `CHANGELOG.md`, a generated `package-lock.json` — **no `node_modules`**. `template.yml`'s `version:` is **stamped from `package.json`**, so the shipped bundle can no longer drift (#71's last task; manual sync dropped from CONTRIBUTING.md).
4. **Publishes** a GitHub Release for the tag with `quantecon-theme.zip` attached — the pinned consumer URL form from PLAN.md Phase 0: `…/releases/download/vX.Y.Z/quantecon-theme.zip`.

Adapted from upstream [`jupyter-book/myst-theme` `theme-assets.yml`](https://github.com/jupyter-book/myst-theme/blob/main/.github/workflows/theme-assets.yml) per PLAN.md, minus the `for THEME in book article` loop and the Changesets coupling.

## Docs

- **CONTRIBUTING.md** — release steps updated: bump `package.json` only (no manual `template.yml` sync), tag, and the workflow does the rest; note that `make deploy` remains only until `lecture-wasm` is repointed.
- **PLAN.md** — Phase 0 status synced (pipeline + version-fold checked off; retro-tagging and the `myst start` resolution check remain).

## Verification

- Workflow YAML parses; CI-equivalent steps reuse the exact scripts from `ci.yml`.
- Dry-ran the changelog extraction and full bundle assembly locally for `2.0.0`: release notes extract cleanly (38 lines), bundle contains the same file set as `make build-theme` plus `package-lock.json`, versions stamped (`package.json` + `template.yml` both `2.0.0`), no `node_modules`, zip = 1281 files.
- End-to-end run happens with the first real tag (next release, per PLAN.md: re-publish via the new flow), which also covers PLAN's '`myst start` resolves the release URL' check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)