### PR TITLE
chore(release): prepare v2.1.0; align docs with the quantecon-theme.mystmd rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,16 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `quantecon-theme.mystmd` repo (Phase 0 of [`PLAN.md`](./PLAN.md)).
 
 ### Added
-- Visual-regression CI gate: a `visual` job pixel-diffs the fixture (desktop + mobile Chromium, now including a sidebar-open snapshot — the off-canvas sidebar was invisible to the existing full-page shots) against committed platform-suffixed baselines on every PR, posts a 🎭 results summary comment, and uploads report/diff artifacts; baselines are refreshed by commenting `/update-snapshots` (or `/update-new-snapshots`) on the PR ([#78](https://github.com/QuantEcon/quantecon-theme-src/pull/78)).
-- Tag-triggered release pipeline (`.github/workflows/release.yml`): pushing a `vX.Y.Z` tag builds the theme, assembles the bundle (with `template.yml`'s `version` stamped from `package.json` so they cannot drift), and publishes a GitHub Release with `quantecon-theme.zip` attached, using the version's changelog section as the release notes ([#77](https://github.com/QuantEcon/quantecon-theme-src/pull/77)).
+- Visual-regression CI gate: a `visual` job pixel-diffs the fixture (desktop + mobile Chromium, now including a sidebar-open snapshot — the off-canvas sidebar was invisible to the existing full-page shots) against committed platform-suffixed baselines on every PR, posts a 🎭 results summary comment, and uploads report/diff artifacts; baselines are refreshed by commenting `/update-snapshots` (or `/update-new-snapshots`) on the PR ([#78](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/78)).
+- Tag-triggered release pipeline (`.github/workflows/release.yml`): pushing a `vX.Y.Z` tag builds the theme, assembles the bundle (with `template.yml`'s `version` stamped from `package.json` so they cannot drift), and publishes a GitHub Release with `quantecon-theme.zip` attached, using the version's changelog section as the release notes ([#77](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/77)).
 
 ### Fixed
-- Top-level (level-1) TOC pages now render as clickable links in the Contents sidebar when they have a slug, so flat-TOC projects are navigable; slug-less grouping titles remain plain headers ([#76](https://github.com/QuantEcon/quantecon-theme-src/pull/76)).
-- Safari/WebKit flash of unstyled content (FOUC) on page navigation: inline a zero-specificity (`:where(...)`) critical-CSS block (base font + `.simple-center-grid` layout) in the document `<head>` so the first paint is already styled before the linked stylesheet applies ([#66](https://github.com/QuantEcon/quantecon-theme-src/pull/66)).
+- Top-level (level-1) TOC pages now render as clickable links in the Contents sidebar when they have a slug, so flat-TOC projects are navigable; slug-less grouping titles remain plain headers ([#76](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/76)).
+- Safari/WebKit flash of unstyled content (FOUC) on page navigation: inline a zero-specificity (`:where(...)`) critical-CSS block (base font + `.simple-center-grid` layout) in the document `<head>` so the first paint is already styled before the linked stylesheet applies ([#66](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/66)).
 
 ### Security
-- Resolve backward-compatible Dependabot advisories via npm `overrides` — `uuid` (`^11.1.1`), `ajv` (`^8.18.0`), and `cookie` (`^0.7.0`, used by Remix's cookie session); add `SECURITY.md` documenting the dependency posture and triage for the remaining deferred alerts ([#68](https://github.com/QuantEcon/quantecon-theme-src/pull/68)).
-- Patch `shell-quote` and `ws` via version-scoped npm `overrides`; refresh the `SECURITY.md` triage ([#75](https://github.com/QuantEcon/quantecon-theme-src/pull/75)).
+- Resolve backward-compatible Dependabot advisories via npm `overrides` — `uuid` (`^11.1.1`), `ajv` (`^8.18.0`), and `cookie` (`^0.7.0`, used by Remix's cookie session); add `SECURITY.md` documenting the dependency posture and triage for the remaining deferred alerts ([#68](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/68)).
+- Patch `shell-quote` and `ws` via version-scoped npm `overrides`; refresh the `SECURITY.md` triage ([#75](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/75)).
 
 ## [2.0.0] - 2026-06-04
 
@@ -53,44 +53,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > deploying.
 
 ### Changed
-- Upgrade all `@myst-theme/*` packages from `0.14.x` to `1.3.0`, and `myst-common`/`myst-config` to `1.9.5`, tracking current upstream [`myst-theme/book`](https://github.com/jupyter-book/myst-theme/tree/main/themes/book) ([#30](https://github.com/QuantEcon/quantecon-theme-src/pull/30) brought 0.14→1.1.2; later bumped to 1.3.0 to match latest upstream). **Upstream breaking change:** `@myst-theme` v1.0.0 introduced a new AST structure for notebook output nodes ([jupyter-book/myst-theme#571](https://github.com/jupyter-book/myst-theme/pull/571)).
-- Raise the Node engine floor from `>=14` to `>=20` (drops EOL Node 18) and move local/CI tooling to **Node 24** (`.nvmrc` + CI + release workflow), matching upstream's build; bump release-workflow actions v3 → v4 ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
+- Upgrade all `@myst-theme/*` packages from `0.14.x` to `1.3.0`, and `myst-common`/`myst-config` to `1.9.5`, tracking current upstream [`myst-theme/book`](https://github.com/jupyter-book/myst-theme/tree/main/themes/book) ([#30](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/30) brought 0.14→1.1.2; later bumped to 1.3.0 to match latest upstream). **Upstream breaking change:** `@myst-theme` v1.0.0 introduced a new AST structure for notebook output nodes ([jupyter-book/myst-theme#571](https://github.com/jupyter-book/myst-theme/pull/571)).
+- Raise the Node engine floor from `>=14` to `>=20` (drops EOL Node 18) and move local/CI tooling to **Node 24** (`.nvmrc` + CI + release workflow), matching upstream's build; bump release-workflow actions v3 → v4 ([#31](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/31)).
 
 ### Added
-- Playwright visual-regression harness: renders a small fixture project (plain Markdown + a notebook) through a live `myst start` against a chosen theme version and snapshots each surface, so styling/markup regressions across the upgrade are caught before deploy ([#60](https://github.com/QuantEcon/quantecon-theme-src/pull/60)).
-- CI workflow (`.github/workflows/ci.yml`) running type-check (`npm run compile`) and a production build (`npm run prod:build`) on every push/PR to `main` ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
-- `CONTRIBUTING.md` documenting development setup, available scripts, project structure, commit conventions, and the release process ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
+- Playwright visual-regression harness: renders a small fixture project (plain Markdown + a notebook) through a live `myst start` against a chosen theme version and snapshots each surface, so styling/markup regressions across the upgrade are caught before deploy ([#60](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/60)).
+- CI workflow (`.github/workflows/ci.yml`) running type-check (`npm run compile`) and a production build (`npm run prod:build`) on every push/PR to `main` ([#31](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/31)).
+- `CONTRIBUTING.md` documenting development setup, available scripts, project structure, commit conventions, and the release process ([#31](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/31)).
 
 ### Fixed
-- **(1.x regression)** Every page returned HTTP 500 under `@myst-theme` 1.x (`useBannerState must be used from within a BannerStateProvider`). Wrap the page tree (article **and** error page) in `BannerStateProvider` so the new `useBannerState`/`useSidebarHeight` hooks resolve ([#61](https://github.com/QuantEcon/quantecon-theme-src/pull/61)).
-- **(1.x regression)** The article body rendered full-bleed (flush-left, no centered content column, right-hand "On this page" margin swallowed). `@myst-theme` 1.x emits `.col-screen` in a later cascade layer than our base-layer centering rule, so the body's `col-screen` wrapper won; drop it so blocks fall back to the centered `col-body` default (matching upstream's `myst-content-blocks` pattern) ([#62](https://github.com/QuantEcon/quantecon-theme-src/pull/62)).
-- **(1.x regression)** Pages flashed continuously (a hard-reload loop) and the in-page "On this page" outline never rendered. Keep `@remix-run/*` pinned to `~1.17.0` (restoring the long-standing v1.0.1 pin; reverting the [#29](https://github.com/QuantEcon/quantecon-theme-src/pull/29) bump to 1.19) — Remix 1.19's client calls `window.location.reload()` whenever `window.__remixContext.url` is undefined, which it always is under the mystmd CLI's SSR. Adds `.npmrc` `legacy-peer-deps=true` and an explicit `typescript` devDependency so installs accept `@myst-theme/site`'s stricter `^1.19` peer range ([#63](https://github.com/QuantEcon/quantecon-theme-src/pull/63)).
-- `aria-label` typo (`aira-label`) in `ProjectFrontmatter.tsx` — the authors section is now exposed to screen readers ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
-- Missing React `key` prop on author `<span>` elements built in a `.reduce()` in `ProjectFrontmatter.tsx` ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
-- Swapped `SidebarToggle.tsx` ARIA labels so each matches its visible icon state ("Show"/"Hide table of contents") ([#31](https://github.com/QuantEcon/quantecon-theme-src/pull/31)).
-- TypeScript errors surfaced by the new CI: add `@types/lodash.throttle`; wrap `Buffer` in `new Uint8Array(...)` for the `Response` body in the `[objects.inv]` and `[favicon.ico]` routes ([#32](https://github.com/QuantEcon/quantecon-theme-src/pull/32)).
+- **(1.x regression)** Every page returned HTTP 500 under `@myst-theme` 1.x (`useBannerState must be used from within a BannerStateProvider`). Wrap the page tree (article **and** error page) in `BannerStateProvider` so the new `useBannerState`/`useSidebarHeight` hooks resolve ([#61](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/61)).
+- **(1.x regression)** The article body rendered full-bleed (flush-left, no centered content column, right-hand "On this page" margin swallowed). `@myst-theme` 1.x emits `.col-screen` in a later cascade layer than our base-layer centering rule, so the body's `col-screen` wrapper won; drop it so blocks fall back to the centered `col-body` default (matching upstream's `myst-content-blocks` pattern) ([#62](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/62)).
+- **(1.x regression)** Pages flashed continuously (a hard-reload loop) and the in-page "On this page" outline never rendered. Keep `@remix-run/*` pinned to `~1.17.0` (restoring the long-standing v1.0.1 pin; reverting the [#29](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/29) bump to 1.19) — Remix 1.19's client calls `window.location.reload()` whenever `window.__remixContext.url` is undefined, which it always is under the mystmd CLI's SSR. Adds `.npmrc` `legacy-peer-deps=true` and an explicit `typescript` devDependency so installs accept `@myst-theme/site`'s stricter `^1.19` peer range ([#63](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/63)).
+- `aria-label` typo (`aira-label`) in `ProjectFrontmatter.tsx` — the authors section is now exposed to screen readers ([#31](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/31)).
+- Missing React `key` prop on author `<span>` elements built in a `.reduce()` in `ProjectFrontmatter.tsx` ([#31](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/31)).
+- Swapped `SidebarToggle.tsx` ARIA labels so each matches its visible icon state ("Show"/"Hide table of contents") ([#31](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/31)).
+- TypeScript errors surfaced by the new CI: add `@types/lodash.throttle`; wrap `Buffer` in `new Uint8Array(...)` for the `Response` body in the `[objects.inv]` and `[favicon.ico]` routes ([#32](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/32)).
 
 ### Security
-- Add `overrides` for `prismjs` (`^1.30.0`, GHSA-x7hr-w5r2-h6wg DOM-clobbering) and `katex` (`^0.16.21`, five CVEs), resolving those advisories ([#29](https://github.com/QuantEcon/quantecon-theme-src/pull/29), [#30](https://github.com/QuantEcon/quantecon-theme-src/pull/30)). The remaining `npm audit` findings live in the older Remix v1 build toolchain (esbuild/webpack and friends); pinning `@remix-run/*` back to `~1.17.0` for rendering correctness (see Fixed, [#63](https://github.com/QuantEcon/quantecon-theme-src/pull/63)) keeps those present until the Remix v2 migration ([#28](https://github.com/QuantEcon/quantecon-theme-src/issues/28)).
+- Add `overrides` for `prismjs` (`^1.30.0`, GHSA-x7hr-w5r2-h6wg DOM-clobbering) and `katex` (`^0.16.21`, five CVEs), resolving those advisories ([#29](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/29), [#30](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/30)). The remaining `npm audit` findings live in the older Remix v1 build toolchain (esbuild/webpack and friends); pinning `@remix-run/*` back to `~1.17.0` for rendering correctness (see Fixed, [#63](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/63)) keeps those present until the Remix v2 migration ([#28](https://github.com/QuantEcon/quantecon-theme.mystmd/issues/28)).
 
 ### Dependencies
 - Numerous Dependabot security updates merged, including `webpack`, `vite`, `vm2`, `tar-fs`, `lodash`/`lodash-es`, `qs`/`express`, `js-yaml`, `form-data`, `brace-expansion`, `@babel/*`, `diff`, and `minimatch`.
 
 ## [1.1.1] - 2025-06-13
 > Deployed to the bundle repo on 2025-06-13. The source version-bump PR
-> ([#8](https://github.com/QuantEcon/quantecon-theme-src/pull/8)) was merged much later,
+> ([#8](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/8)) was merged much later,
 > on 2026-02-25, as bookkeeping — it did not change what users were running.
 
 ### Fixed
-- Strip the `.myst` suffix from the derived `org/repo` when building Colab / JupyterHub launch URLs, so lecture repos named `lecture-*.myst` produce working notebook links (`6e39113`, [#4](https://github.com/QuantEcon/quantecon-theme-src/pull/4)).
+- Strip the `.myst` suffix from the derived `org/repo` when building Colab / JupyterHub launch URLs, so lecture repos named `lecture-*.myst` produce working notebook links (`6e39113`, [#4](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/4)).
 
 ### Removed
-- Dropped the no-longer-needed `@types/react-syntax-highlighter` patch ([#8](https://github.com/QuantEcon/quantecon-theme-src/pull/8)).
+- Dropped the no-longer-needed `@types/react-syntax-highlighter` patch ([#8](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/8)).
 
 ## [1.1.0] - 2025-02-28
 
 ### Changed
-- Update `@myst-theme/*` to `0.14.0` (`df3bcd4`, [#2](https://github.com/QuantEcon/quantecon-theme-src/pull/2)).
+- Update `@myst-theme/*` to `0.14.0` (`df3bcd4`, [#2](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/2)).
 
 ## [1.0.6] - 2025-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,24 @@ documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-> **Release flow.** This theme is developed here in `quantecon-theme-src` and
-> deployed (bundled) to [`QuantEcon/quantecon-theme`](https://github.com/QuantEcon/quantecon-theme)
-> via `make deploy`. The deploy step copies this file into the bundled repo, so this
-> is the canonical changelog. The version comes from `package.json`; each release is a
-> deploy commit (`🚀 vX.Y.Z from <sha>`) in the bundled repo. There are currently no
-> git tags (see Phase 0 in [`PLAN.md`](./PLAN.md)).
+> **Release flow.** This theme is developed in
+> [`QuantEcon/quantecon-theme.mystmd`](https://github.com/QuantEcon/quantecon-theme.mystmd)
+> (renamed from `quantecon-theme-src` on 2026-06-11; old links redirect). Each release
+> is a `vX.Y.Z` git tag: pushing the tag triggers `release.yml`, which builds the theme
+> and publishes a GitHub Release with `quantecon-theme.zip` attached, using that
+> version's section of this file as the release notes (see
+> [`CONTRIBUTING.md`](./CONTRIBUTING.md)). Releases ≤ 2.0.0 predate the pipeline and
+> were deploy commits (`🚀 vX.Y.Z from <sha>`) to the legacy build repo
+> [`QuantEcon/quantecon-theme`](https://github.com/QuantEcon/quantecon-theme), which
+> stays updated via `make deploy` only until consumers move to pinned release URLs
+> (see Phase 0 in [`PLAN.md`](./PLAN.md)).
 
 ## [Unreleased]
+
+## [2.1.0] - 2026-06-11
+
+> First release published through the tag-triggered pipeline, from the renamed
+> `quantecon-theme.mystmd` repo (Phase 0 of [`PLAN.md`](./PLAN.md)).
 
 ### Added
 - Visual-regression CI gate: a `visual` job pixel-diffs the fixture (desktop + mobile Chromium, now including a sidebar-open snapshot — the off-canvas sidebar was invisible to the existing full-page shots) against committed platform-suffixed baselines on every PR, posts a 🎭 results summary comment, and uploads report/diff artifacts; baselines are refreshed by commenting `/update-snapshots` (or `/update-new-snapshots`) on the PR ([#78](https://github.com/QuantEcon/quantecon-theme-src/pull/78)).
@@ -25,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - Resolve backward-compatible Dependabot advisories via npm `overrides` — `uuid` (`^11.1.1`), `ajv` (`^8.18.0`), and `cookie` (`^0.7.0`, used by Remix's cookie session); add `SECURITY.md` documenting the dependency posture and triage for the remaining deferred alerts ([#68](https://github.com/QuantEcon/quantecon-theme-src/pull/68)).
+- Patch `shell-quote` and `ws` via version-scoped npm `overrides`; refresh the `SECURITY.md` triage ([#75](https://github.com/QuantEcon/quantecon-theme-src/pull/75)).
 
 ## [2.0.0] - 2026-06-04
 
@@ -116,14 +127,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial version of the QuantEcon MyST theme: Remix + `@myst-theme` book theme with QuantEcon branding, toolbar (home, search, fullscreen, font scaling, dark mode, downloads, Colab/JupyterHub launch, edit-on-GitHub), content-driven site footer, and bundled brand assets.
 
-[Unreleased]: https://github.com/QuantEcon/quantecon-theme-src/compare/v2.0.0...HEAD
-[2.0.0]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.1.1...v2.0.0
-[1.1.1]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.6...v1.1.0
-[1.0.6]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.5...v1.0.6
-[1.0.5]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.4...v1.0.5
-[1.0.4]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.3...v1.0.4
-[1.0.3]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.2...v1.0.3
-[1.0.2]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/QuantEcon/quantecon-theme-src/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/QuantEcon/quantecon-theme-src/releases/tag/v1.0.0
+[Unreleased]: https://github.com/QuantEcon/quantecon-theme.mystmd/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/QuantEcon/quantecon-theme.mystmd/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/QuantEcon/quantecon-theme.mystmd/compare/v1.1.1...v2.0.0
+[1.1.1]: https://github.com/QuantEcon/quantecon-theme.mystmd/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/QuantEcon/quantecon-theme.mystmd/compare/v1.0.6...v1.1.0
+[1.0.6]: https://github.com/QuantEcon/quantecon-theme.mystmd/compare/v1.0.5...v1.0.6
+[1.0.5]: https://github.com/QuantEcon/quantecon-theme.mystmd/compare/v1.0.4...v1.0.5
+[1.0.4]: https://github.com/QuantEcon/quantecon-theme.mystmd/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/QuantEcon/quantecon-theme.mystmd/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/QuantEcon/quantecon-theme.mystmd/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/QuantEcon/quantecon-theme.mystmd/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/QuantEcon/quantecon-theme.mystmd/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to quantecon-theme-src
+# Contributing to quantecon-theme.mystmd
 
 Thank you for your interest in contributing to the QuantEcon theme!
 
@@ -11,8 +11,8 @@ Thank you for your interest in contributing to the QuantEcon theme!
 
 ```bash
 # Clone the repository
-git clone https://github.com/QuantEcon/quantecon-theme-src.git
-cd quantecon-theme-src
+git clone https://github.com/QuantEcon/quantecon-theme.mystmd.git
+cd quantecon-theme.mystmd
 
 # Install dependencies
 npm install

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,7 @@
 # PLAN — QuantEcon MyST theme feature parity with `quantecon-book-theme`
 
-This plan tracks bringing the MyST theme (this repo, `quantecon-theme-src`, bundled
+This plan tracks bringing the MyST theme (this repo, `quantecon-theme.mystmd` —
+formerly `quantecon-theme-src` — bundled
 to [`QuantEcon/quantecon-theme`](https://github.com/QuantEcon/quantecon-theme)) to
 feature parity with the Sphinx / Jupyter-Book&lt;2 theme
 [`quantecon-book-theme`](https://github.com/QuantEcon/quantecon-book-theme) ahead of
@@ -90,8 +91,8 @@ upstream is heading.
   it to a release, point the URL at it.
 
 **Repo consolidation & rename:**
-- [ ] Rename `quantecon-theme-src` → **`quantecon-theme.mystmd`** (GitHub 301-redirects the
-      old URLs; update the local `origin` remote).
+- [x] Rename `quantecon-theme-src` → **`quantecon-theme.mystmd`** (GitHub 301-redirects the
+      old URLs; update the local `origin` remote). *(Done 2026-06-11.)*
 - [ ] Once releases are live, **archive** the old build repo `QuantEcon/quantecon-theme`
       with a README note pointing to the new repo + release assets; do not reuse the name.
 - [ ] Retire the `make deploy` / `build-theme` / `deploy-theme` Makefile targets (replaced
@@ -162,12 +163,13 @@ upstream is heading.
       `quantecon-.*`, which already matches the new name.
 
 **Hygiene carried over:**
-- [ ] Fix naming/branding drift: package name **reconciled to `@quantecon/lecture-theme`**
+- [x] Fix naming/branding drift: package name **reconciled to `@quantecon/lecture-theme`**
       across `package.json` + `template/package.json` in
-      [#72](https://github.com/QuantEcon/quantecon-theme-src/pull/72); still TODO — align
-      `template.yml` `title`/`source` with the new repo name once the repo is renamed.
-- [ ] De-duplicate the two "Development" sections in `README.md` and update the Usage URL to
-      the pinned-release form.
+      [#72](https://github.com/QuantEcon/quantecon-theme-src/pull/72); `template.yml`
+      `title`/`source` aligned with the renamed repo in
+      [#79](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/79).
+- [x] De-duplicate the two "Development" sections in `README.md` and update the Usage URL to
+      the pinned-release form ([#79](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/79)).
 - [x] Triaged & consolidated the ~20 Dependabot PRs into a single lockfile refresh
       ([#55](https://github.com/QuantEcon/quantecon-theme-src/pull/55)–58; `npm audit`
       68 → 45). The remaining findings need the Remix v2 migration ([#28]) — still to schedule.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# A QuantEcon Book for MyST Markdown
+# QuantEcon Lecture Theme — for MyST Markdown
 
-A dedicated MyST interactive book theme for the QuantEcon lectures and books.
+A dedicated MyST interactive book theme (`@quantecon/lecture-theme`) for the
+QuantEcon lectures and books, distributed as a zip attached to each
+[GitHub Release](https://github.com/QuantEcon/quantecon-theme.mystmd/releases).
 
 - Responsive and mobile ready
 - Page Footer based on MyST Content
@@ -10,7 +12,7 @@ A dedicated MyST interactive book theme for the QuantEcon lectures and books.
 
 ### Downloads
 
-A when downloads are available on a page a download button will appear in the top toolbar.
+When downloads are available on a page a download button will appear in the top toolbar.
 The contents of the menu available from that button is configured via the [download configuration](https://mystmd.org/guide/website-downloads) of the MyST project and page.
 Typically, a download of the entire book as a PDF is provided along with downloads of each lecture in PDF and Notebook (md) form.
 
@@ -53,11 +55,12 @@ The launch notebooks capability has been developed to mirror capabilities in the
 
 ## Usage with MyST
 
-To use this template locally, update your site template make sure your project's local dependencies are installed:
+Point your project's `site.template` at a **pinned release** zip:
 
-```sh
+```yaml
+# myst.yml
 site:
-  template: https://github.com/QuantEcon/quantecon-theme/archive/refs/heads/main.zip
+  template: https://github.com/QuantEcon/quantecon-theme.mystmd/releases/download/v2.1.0/quantecon-theme.zip
 ```
 
 Then start the local server:
@@ -70,37 +73,26 @@ Open up [http://localhost:3000](http://localhost:3000) and you should be ready t
 
 ## Development
 
-To run a local development server:
+After cloning the repository, install the packages and start the dev server
+(with CSS watch and hot reload):
 
 ```sh
-cd quantecon-theme
 npm install
 npm run dev
 ```
+
+To preview against real MyST content instead, run a headless content server in
+your content project (`myst start --headless`) alongside the theme dev server.
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the full development setup,
+available scripts, and the test suites, and [`tests/visual/README.md`](./tests/visual/README.md)
+for the visual-regression harness.
 
 ## Release
 
-To bundle and release this theme run:
-
-```sh
-make deploy
-```
-
-This will build a bundled version of the theme and push to the repository at https://github.com/curvenote-themes/quantecon.
-
-## Development
-
-Run a myst content server:
-
-```
-myst start --headless
-```
-
-After cloning the repository, install the packages and start the server:
-
-```
-npm install
-npm run dev
-```
-
-You should then be able to make changes with hot-reload.
+Releases are cut by pushing a `vX.Y.Z` git tag: the
+[`release.yml`](./.github/workflows/release.yml) workflow builds the theme and
+publishes a GitHub Release with `quantecon-theme.zip` attached, using that
+version's [`CHANGELOG.md`](./CHANGELOG.md) section as the release notes. The
+step-by-step flow is documented in
+[`CONTRIBUTING.md`](./CONTRIBUTING.md#releases).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ QuantEcon lectures and books, distributed as a zip attached to each
 
 ### Downloads
 
-When downloads are available on a page a download button will appear in the top toolbar.
+When downloads are available on a page, a download button will appear in the top toolbar.
 The contents of the menu available from that button is configured via the [download configuration](https://mystmd.org/guide/website-downloads) of the MyST project and page.
 Typically, a download of the entire book as a PDF is provided along with downloads of each lecture in PDF and Notebook (md) form.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quantecon/lecture-theme",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@quantecon/lecture-theme",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "dependencies": {
         "@myst-theme/common": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantecon/lecture-theme",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "sideEffects": false,
   "scripts": {

--- a/template.yml
+++ b/template.yml
@@ -1,9 +1,9 @@
 jtex: v1
-title: QuantEcon
+title: QuantEcon Lecture Theme
 description: A dedicated theme for the QuantEcon course materials
-version: 2.0.0
+version: 2.1.0
 license: MIT
-source: https://github.com/QuantEcon/quantecon-theme
+source: https://github.com/QuantEcon/quantecon-theme.mystmd
 thumbnail: ./thumbnail.png
 authors:
   - name: Steve Purves


### PR DESCRIPTION
## Summary

Release prep for **v2.1.0** — the first release to go through the tag-triggered pipeline (#77), from the renamed repo. Plus the last Phase 0 naming-drift hygiene items, now that the rename to `quantecon-theme.mystmd` is done.

### Release prep
- `package.json` / `package-lock.json` → **2.1.0** (changes since 2.0.0: visual CI gate #78, release pipeline #77, sidebar links fix #76, FOUC fix #66/#67, security overrides #68/#75 — a minor bump: additive features + fixes, no consumer-breaking changes).
- `CHANGELOG.md`: rolled `## [Unreleased]` into `## [2.1.0] - 2026-06-11`, added the **missed #75 security entry** (shell-quote/ws overrides), rewrote the header release-flow note (was still describing the `make deploy` flow and "no git tags"), and pointed the footer compare links at the renamed repo.
- Verified the release workflow's guards against this prep: the changelog extraction finds the `## [2.1.0]` section, and the tag guard will match `v2.1.0`.

### Rename alignment (PLAN.md Phase 0 hygiene)
- `template.yml`: `title` → **QuantEcon Lecture Theme**, `source` → the renamed repo, `version` → 2.1.0.
- `README.md`: usage URL switched to the **pinned-release form**; the two duplicate Development sections merged into one; the stale Release section (`make deploy` pushing to a `curvenote-themes` URL!) replaced with the tag-triggered flow; title/branding updated.
- `CONTRIBUTING.md` clone URL/title; `PLAN.md` checkboxes synced.

## After merge

```bash
git checkout main && git pull
git tag v2.1.0 && git push origin v2.1.0
```

…which fires the first end-to-end run of `release.yml`. I'll then verify `myst start` resolves the release-asset URL (the last unchecked pipeline box) before we repoint `lecture-wasm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)