### PR TITLE
chore: retire make deploy; assemble build-theme locally; add build-zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > version's section of this file as the release notes (see
 > [`CONTRIBUTING.md`](./CONTRIBUTING.md)). Releases ≤ 2.0.0 predate the pipeline and
 > were deploy commits (`🚀 vX.Y.Z from <sha>`) to the legacy build repo
-> [`QuantEcon/quantecon-theme`](https://github.com/QuantEcon/quantecon-theme), which
-> stays updated via `make deploy` only until consumers move to pinned release URLs
-> (see Phase 0 in [`PLAN.md`](./PLAN.md)).
+> [`QuantEcon/quantecon-theme`](https://github.com/QuantEcon/quantecon-theme), now
+> **archived** — consumers point at pinned release URLs (see Phase 0 in
+> [`PLAN.md`](./PLAN.md)).
 
 ## [Unreleased]
+
+### Removed
+- Retire the `make deploy` / `deploy-theme` targets — releases ship exclusively via the tag-triggered GitHub Release workflow, and the legacy build repo (`QuantEcon/quantecon-theme`) is archived. `make build-theme` now assembles the bundle locally instead of cloning the archived repo (so the CI test harness no longer depends on it), and a new `make build-zip` produces the release-equivalent zip for local artifact testing ([#81](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/81)).
 
 ## [2.1.0] - 2026-06-11
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,10 +116,10 @@ If a release run fails, the failed run published nothing, so recovery is safe:
   git push --force origin vX.Y.Z
   ```
 
-> **Note:** consumers are still being migrated to pinned release URLs
-> (see [#71](https://github.com/QuantEcon/quantecon-theme-src/issues/71) and PLAN.md
-> Phase 0). Until `lecture-wasm` is repointed, also run `make deploy` to update the
-> legacy `QuantEcon/quantecon-theme` build repo.
+To test the bundle/artifact locally without cutting a release, use
+`make build-theme` (assembles the bundle into `.deploy/quantecon-theme`, as used
+by the visual test harness) or `make build-zip` (also produces the
+release-equivalent zip).
 
 ## Notes
 

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,33 @@
-.PHONY: build-theme build-quantecon deploy deploy-theme deploy-quantecon check
+.PHONY: check build-theme build-zip
 
-COMMIT = $(shell git rev-parse --short HEAD)
-# You may need to install jq for this to work!
+# Releases ship via the tag-triggered GitHub Release workflow
+# (.github/workflows/release.yml) — see CONTRIBUTING.md "Releases".
+# The old `make deploy` flow (pushing the bundle to the now-archived
+# QuantEcon/quantecon-theme build repo) was retired with it.
+
+THEME = quantecon-theme
 VERSION = $(shell cat package.json | jq -r '.version')
 
-THEME=quantecon-theme
-
 check:
-	@which jq > /dev/null || (echo "Error: the jq linux command is not available. Please install it first (brew install jq | apt-get install jq)." && exit 1)
+	@which jq > /dev/null || (echo "Error: the jq command is not available. Please install it first (brew install jq | apt-get install jq)." && exit 1)
 
-build-theme:
-	mkdir .deploy || true
+# Assembles the same bundle the release workflow ships into .deploy/$(THEME).
+# Used by the visual/FOUC test harness (THEME_TEMPLATE=$$PWD/.deploy/$(THEME))
+# and for local artifact testing.
+build-theme: check
 	rm -rf .deploy/$(THEME)
-	git clone --depth 1 https://github.com/QuantEcon/$(THEME) .deploy/$(THEME)
-	rm -rf .deploy/$(THEME)/public .deploy/$(THEME)/build .deploy/$(THEME)/package.json .deploy/$(THEME)/package-lock.json .deploy/$(THEME)/template.yml .deploy/$(THEME)/server.js
-	find template -type f  -exec cp {} .deploy/$(THEME) \;
+	mkdir -p .deploy/$(THEME)
+	find template -type f -exec cp {} .deploy/$(THEME) \;
 	npm run prod:build
 	cp -r public .deploy/$(THEME)/public
 	cp -r build .deploy/$(THEME)/build
-	cp -r template.yml .deploy/$(THEME)/template.yml
-	cp -r CHANGELOG.md .deploy/$(THEME)/CHANGELOG.md
-	cp -r template/thumbnail.png .deploy/$(THEME)/thumbnail.png
-	cp -r template/qe-logo.png .deploy/$(THEME)/qe-logo.png
-	cp -r template/README.md .deploy/$(THEME)/README.md
-	sed -i.bak "s/template/$(THEME)/g" .deploy/$(THEME)/package.json
-	sed -i.bak "s/VERSION/$(VERSION)/g" .deploy/$(THEME)/package.json
-	rm .deploy/$(THEME)/package.json.bak
+	cp CHANGELOG.md .deploy/$(THEME)/CHANGELOG.md
+	sed -i.bak "s/VERSION/$(VERSION)/g" .deploy/$(THEME)/package.json && rm .deploy/$(THEME)/package.json.bak
+	sed -E "s/^version: .*/version: $(VERSION)/" template.yml > .deploy/$(THEME)/template.yml
 	cd .deploy/$(THEME) && npm install
 
-build-quantecon:
-	make THEME=quantecon-theme build-theme
-
-deploy-theme: check
-	echo "Deploying $(THEME) theme to QuantEcon/$(THEME)"
-	echo "Version: $(VERSION)"
-	make THEME=$(THEME) build-theme
-	cd .deploy/$(THEME) && git add .
-	cd .deploy/$(THEME) && git commit -m "🚀 v$(VERSION) from $(COMMIT)"
-	cd .deploy/$(THEME) && git push -u origin main
-
-
-deploy: deploy-quantecon
-
-deploy-quantecon:
-	make THEME=quantecon-theme deploy-theme
+# Zips the bundle for testing the release artifact locally (the release
+# workflow attaches the equivalent zip to the GitHub Release).
+build-zip: build-theme
+	cd .deploy && rm -f $(THEME).zip && zip -rq $(THEME).zip $(THEME) -x "$(THEME)/node_modules/*"
+	@echo "Wrote .deploy/$(THEME).zip"

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,10 @@ VERSION = $(shell cat package.json | jq -r '.version')
 check:
 	@which jq > /dev/null || (echo "Error: the jq command is not available. Please install it first (brew install jq | apt-get install jq)." && exit 1)
 
-# Assembles the same bundle the release workflow ships into .deploy/$(THEME).
-# Used by the visual/FOUC test harness (THEME_TEMPLATE=$$PWD/.deploy/$(THEME))
-# and for local artifact testing.
+# Assembles the release workflow's bundle into .deploy/$(THEME), then
+# npm-installs it so the visual/FOUC test harness can serve it directly
+# (THEME_TEMPLATE=$$PWD/.deploy/$(THEME)). The node_modules this creates is
+# local-only — `build-zip` excludes it, matching the release asset.
 build-theme: check
 	rm -rf .deploy/$(THEME)
 	mkdir -p .deploy/$(THEME)
@@ -26,8 +27,9 @@ build-theme: check
 	sed -E "s/^version: .*/version: $(VERSION)/" template.yml > .deploy/$(THEME)/template.yml
 	cd .deploy/$(THEME) && npm install
 
-# Zips the bundle for testing the release artifact locally (the release
-# workflow attaches the equivalent zip to the GitHub Release).
+# Zips the bundle for testing the release artifact locally — node_modules
+# excluded, so the zip's contents match what the release workflow attaches
+# to the GitHub Release (which ships only a lockfile).
 build-zip: build-theme
 	cd .deploy && rm -f $(THEME).zip && zip -rq $(THEME).zip $(THEME) -x "$(THEME)/node_modules/*"
 	@echo "Wrote .deploy/$(THEME).zip"

--- a/PLAN.md
+++ b/PLAN.md
@@ -93,10 +93,15 @@ upstream is heading.
 **Repo consolidation & rename:**
 - [x] Rename `quantecon-theme-src` → **`quantecon-theme.mystmd`** (GitHub 301-redirects the
       old URLs; update the local `origin` remote). *(Done 2026-06-11.)*
-- [ ] Once releases are live, **archive** the old build repo `QuantEcon/quantecon-theme`
+- [x] Once releases are live, **archive** the old build repo `QuantEcon/quantecon-theme`
       with a README note pointing to the new repo + release assets; do not reuse the name.
-- [ ] Retire the `make deploy` / `build-theme` / `deploy-theme` Makefile targets (replaced
+      *(Done 2026-06-11, after `lecture-wasm` was repointed in
+      [lecture-wasm#48](https://github.com/QuantEcon/lecture-wasm/pull/48).)*
+- [x] Retire the `make deploy` / `build-theme` / `deploy-theme` Makefile targets (replaced
       by the release workflow); keep a local `make build-zip` for testing the artifact.
+      *(Done in [#81](https://github.com/QuantEcon/quantecon-theme.mystmd/pull/81):
+      deploy targets removed; `build-theme` retained for the test harness but now
+      assembles locally instead of cloning the archived repo; `build-zip` added.)*
 
 **Release pipeline (adapt upstream `theme-assets.yml`):**
 - [x] Add a workflow that, on a `vX.Y.Z` tag, builds (`npm run prod:build`), assembles the
@@ -154,14 +159,19 @@ upstream is heading.
       waits for the consumer migration below.
 
 **Consumer migration (now unblocked — `v2.1.0` is published on the new flow):**
-- [ ] Repoint the **only current consumer**, `QuantEcon/lecture-wasm`
+- [x] Repoint the **only current consumer**, `QuantEcon/lecture-wasm`
       ([`lectures/myst.yml:120`](https://github.com/QuantEcon/lecture-wasm/blob/main/lectures/myst.yml#L120)),
       from `…/quantecon-theme/archive/refs/heads/main.zip` to the new pinned release URL
       (`…/quantecon-theme.mystmd/releases/download/v2.1.0/quantecon-theme.zip`); verify
       `myst start` / `myst build --html` renders it.
-- [ ] **Order matters** — migrate the consumer *before* archiving the old build repo:
+      *(Done in [lecture-wasm#48](https://github.com/QuantEcon/lecture-wasm/pull/48):
+      verified locally via `myst start` + the PR's Netlify preview; superseded
+      [lecture-wasm#47](https://github.com/QuantEcon/lecture-wasm/pull/47), closed. The
+      Netlify app's duplicate auto-build fails independently —
+      [lecture-wasm#49](https://github.com/QuantEcon/lecture-wasm/issues/49).)*
+- [x] **Order matters** — migrate the consumer *before* archiving the old build repo:
       land pipeline → publish the first release (`v2.1.0`) → repoint `lecture-wasm` → then
-      archive `QuantEcon/quantecon-theme`.
+      archive `QuantEcon/quantecon-theme`. *(Order held.)*
 - [ ] The flagship lecture repos (`lecture-python.myst`, `lecture-julia.myst`,
       `lecture-datascience.myst`, `lecture-python-advanced.myst`, …) still use the Sphinx
       `quantecon-book-theme` and are **not** consumers yet — each gets repointed as it cuts

--- a/tests/visual/README.md
+++ b/tests/visual/README.md
@@ -26,7 +26,7 @@ either a local theme **build directory** or a GitHub **archive zip URL**.
 | Target | `THEME_TEMPLATE` |
 | ------ | ---------------- |
 | **This repo (current candidate)** | a local build dir — `make build-theme` then `$PWD/.deploy/quantecon-theme` |
-| **The live deployed bundle** | the build repo's `main` archive (moving HEAD = whatever is currently deployed) — `https://github.com/QuantEcon/quantecon-theme/archive/refs/heads/main.zip` |
+| **A released bundle** | the pinned release-asset URL — `https://github.com/QuantEcon/quantecon-theme.mystmd/releases/download/vX.Y.Z/quantecon-theme.zip` |
 
 The committed `__snapshots__/` baselines are **platform-suffixed** — font
 antialiasing differs across OSes, so each platform diffs against pixels it


### PR DESCRIPTION
## Summary

Final Phase 0 cleanup now that the legacy build repo is **archived** and the only consumer is on pinned release URLs (lecture-wasm#48).

- **Remove** the `deploy` / `deploy-theme` / `deploy-quantecon` / `build-quantecon` Makefile targets — releases ship exclusively via the tag-triggered workflow (#77).
- **Rewrite `make build-theme`** to assemble the bundle locally, mirroring the release workflow's assembly. This also removes a hidden dependency: the old target staged the bundle inside a `git clone` of `QuantEcon/quantecon-theme`, so the CI test harness (visual + FOUC jobs, `/update-snapshots`) silently depended on the archived repo's availability. The target name is unchanged, so the three workflows that call it need no edits.
- **Add `make build-zip`** — the release-equivalent zip for local artifact testing (the `build-zip` PLAN.md promised).
- **Docs synced**: CONTRIBUTING release section (interim `make deploy` note → local artifact-testing instructions), CHANGELOG header note (build repo now archived) + Removed entry, visual-test README `THEME_TEMPLATE` table (release-asset URL replaces the retired `main.zip`), PLAN.md checkboxes (archive ✓, retirement ✓, consumer migration ✓).

## Verification

- `make build-zip`: bundle assembled with versions stamped (`package.json` + `template.yml` at 2.1.0), zip = **1281 files, no `node_modules`** — identical in shape to the published v2.1.0 release asset.
- Full visual + FOUC suite passes against the locally-assembled bundle (**10/10**) — and this PR's own CI exercises the new `build-theme` in both jobs.

## Phase 0 status after this merges

Only the retro-tags remain (maintainer action; commands prepared), plus the two deliberately deferred items (Netlify-style preview, real-lecture smoke test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)