### PR TITLE
ci: bump actions to Node 24 runtimes ahead of the June 16 default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     name: Build & Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
@@ -29,8 +29,8 @@ jobs:
       contents: read
       pull-requests: write # daun/playwright-report-summary PR comment
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
@@ -52,14 +52,14 @@ jobs:
           THEME_TEMPLATE: ${{ github.workspace }}/.deploy/quantecon-theme
           PORT: "3111"
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: visual-playwright-report
           path: playwright-report/
           retention-days: 30
       - name: Upload test results (actual/diff images) on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: steps.visual.outcome == 'failure'
         with:
           name: visual-test-diff
@@ -83,8 +83,8 @@ jobs:
     name: FOUC guard (WebKit)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
@@ -102,7 +102,7 @@ jobs:
         env:
           THEME_TEMPLATE: ${{ github.workspace }}/.deploy/quantecon-theme
           PORT: "3111"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: failure()
         with:
           name: fouc-playwright-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
     name: Build & publish release zip
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
@@ -89,7 +89,7 @@ jobs:
           (cd dist && zip -r ../quantecon-theme.zip quantecon-theme)
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body_path: release-notes.md
           files: quantecon-theme.zip

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Get PR branch
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -55,10 +55,10 @@ jobs:
             });
             core.setOutput('ref', pr.data.head.ref);
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ steps.pr.outputs.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
## Summary

GitHub forces the Node 24 runtime for JavaScript actions starting **2026-06-16** (and removes Node 20 from runners 2026-09-16) — flagged as annotations on recent runs. This bumps every Node-20 action in the `main` workflows to its **lowest Node-24 major**, chosen deliberately over "latest" to keep each change a pure runtime port:

| Action | From → To | Notes |
|---|---|---|
| `actions/checkout` | v4 → **v5** | Pure node24 port. Deliberately **not v6**, which changes credential persistence that `update-snapshots.yml`'s branch push relies on. |
| `actions/setup-node` | v4 → **v5** | node24. Its new `packageManager` auto-caching is a no-op here (no `packageManager` field; `cache: npm` is explicit). |
| `actions/upload-artifact` | v4 → **v5** | node24 port ("not a breaking change per-se"). |
| `actions/github-script` | v7 → **v8** | node24; the API surface used (`github.rest.pulls.get`, `core.setOutput`) is unchanged. |
| `softprops/action-gh-release` | v2 → **v3** | Explicit node20→node24 major; inputs unchanged. |

`daun/playwright-report-summary@v4` already runs node24 — left as is. Every target version was verified against its tag's `action.yml` (`runs.using: node24`).

## Validation

- This PR's own CI run exercises the bumped `checkout`/`setup-node`/`upload-artifact` (and `playwright-report-summary`) across all three jobs.
- `update-snapshots.yml` (github-script v8) and `release.yml` (gh-release v3) only fire on comment/tag — verified by runtime inspection + release notes; first real exercise will be the next `/update-snapshots` comment and the next version tag.

## Out of scope

- `preview.yml` (PR #84, unmerged) — its `checkout`/`setup-node` get the same bump as a commit on that branch.
- `rossjrw/pr-preview-action@v1` internally pins node20 builds of JamesIves/deploy + marocchino/sticky-comment; that's upstream's to update (tracked by their repo), and forced node24 is expected to be tolerated.
- No CHANGELOG entry: consumer-invisible CI chore, and the `[Unreleased]` section is already contended by #83/#84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)