### PR TITLE
feat(launch): generalise notebook repo/branch config + nested-dir paths (Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run compile
+      - run: npm run test:unit
       - run: npm run prod:build
 
   # Pixel-diffs the fixture against the committed -linux baselines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,10 @@ Thank you for your interest in contributing to the QuantEcon theme!
 
 ## Prerequisites
 
-- **Node.js** ≥ 18 (see `.nvmrc`)
+- **Node.js** ≥ 18 (see `.nvmrc`). Running the unit tests (`npm run test:unit`)
+  additionally requires **Node ≥ 23.6**, which strips TypeScript on the fly so the
+  tests can import the `.ts` builders without a build step — this matches the CI
+  Node 24 runner. The built theme itself still supports Node ≥ 20 (`engines.node`).
 - **npm** 8.x (see `packageManager` in `package.json`)
 
 ## Development Setup
@@ -30,6 +33,7 @@ The dev server runs at `http://localhost:3000` by default.
 | `npm run dev`       | Start dev server with CSS watch + hot reload     |
 | `npm run prod:build`| Production build (CSS + Thebe assets + Remix)    |
 | `npm run compile`   | TypeScript type-check (`tsc --noEmit`)           |
+| `npm run test:unit` | Pure-function unit tests (`node --test`, Node ≥ 23.6) |
 | `npm run format`    | Format code with Prettier                        |
 | `npm run clean`     | Remove build artifacts                           |
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -280,12 +280,24 @@ stripping) + `docs/user/launch.md`.
       merge — recoverable from that history if demand appears). The Private
       JupyterHub option remains for now; its possible removal (collapsing the
       launcher to a direct Colab button) is tracked in #87.
-- [ ] Generalise the hardcoded `.notebooks` suffix and `main` branch
-      (`LaunchButton.tsx:9–11`) into config read from project frontmatter / `myst.yml`,
-      so non-default branches and naming work.
-- [ ] Verify Colab path handling for **nested** lecture dirs (book-theme strips
-      `path_to_docs` and applies `nb_path_to_notebooks`; the MyST version currently uses
-      only `page.location.split('.')[0]`).
+- [x] Generalise the hardcoded `.notebooks` suffix and `main` branch into config under
+      `site.options` in `myst.yml` (MyST's analog of the book-theme `html_theme_options`),
+      so non-default branches and naming work. New optional keys (defaults reproduce the
+      historical behaviour, so existing lectures are unchanged): `launch_repo_suffix`
+      (default `.notebooks`), `launch_branch` (default `main`), plus `launch_repo_url`
+      to point at an arbitrary notebook repo (book-theme `nb_repository_url` parity).
+      URL logic extracted to pure, unit-tested builders in `launchUrls.ts`; applies to
+      **both** the Colab and the Private-JupyterHub launch URLs. Done in
+      `feat/launch-parity-phase2`.
+- [x] Fix Colab/JupyterHub path handling for **nested** lecture dirs: strip the source
+      extension robustly (the old `page.location.split('.')[0]` truncated paths/dirs
+      containing a dot), strip `launch_source_path` (book-theme `path_to_docs`) and
+      prepend `launch_notebooks_path` (book-theme `nb_path_to_notebooks`). Covered by
+      `tests/unit/launch-urls.test.mjs`.
+
+**Note:** removing the Private JupyterHub option (collapse to a single Colab button, #87)
+is deliberately kept out of this work — it's gated on a maintainer demand signal — so the
+generalisation above covers both Colab and the hub. See #87.
 
 **Effort:** M. **Risk:** low–medium. **Deps:** Phase 0.
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,24 @@ downloads:
 
 ### Launch Notebooks
 
-The launch notebooks capability has been developed to mirror capabilities in the previous QuantEcon theme. It is assumed that the `.notebooks` suffix convention for repository naming is used when launching both Google Colab and Private Jupyter Hub sessions.
+The launch notebooks capability has been developed to mirror capabilities in the previous QuantEcon theme. By default it assumes the `.notebooks` suffix convention for repository naming when launching both Google Colab and Private Jupyter Hub sessions.
 
 Colab is the primary launch target (it provides GPU access for the lectures that
 need it). BinderHub is deliberately not offered — it proved flaky in practice;
 see issue [#26](https://github.com/QuantEcon/quantecon-theme.mystmd/issues/26),
 kept open as a demand-driven future request.
+
+The repo/branch/path conventions are configurable under `site.options` in
+`myst.yml` (MyST's theme-options section). All keys are optional and the
+defaults reproduce the behaviour above, so existing projects need no changes:
+
+| Option | Default | Purpose |
+| ------ | ------- | ------- |
+| `launch_repo_suffix` | `.notebooks` | Suffix appended to the source repo to locate the notebook repo |
+| `launch_branch` | `main` | Branch in the notebook repo to launch from |
+| `launch_repo_url` | _(derived from `github` + suffix)_ | Explicit notebook repo, for when it isn't `<source>.notebooks` |
+| `launch_notebooks_path` | _(none)_ | Sub-directory within the notebook repo where the notebooks live |
+| `launch_source_path` | _(none)_ | Path prefix stripped from the page location (e.g. a `lectures/` source dir) |
 
 ## Usage with MyST
 

--- a/app/components/toolbar/LaunchButton.tsx
+++ b/app/components/toolbar/LaunchButton.tsx
@@ -15,7 +15,7 @@ function LaunchPanel() {
   const launchOptions: TemplateOptions =
     (useSiteManifest() as SiteManifest & TemplateOptions)?.options ?? {};
   const [service, setService] = React.useState<string | undefined>('colab');
-  const [privateServiceUrl, setPrivateServiceUrl] = React.useState<string | undefined>();
+  const [privateServiceUrl, setPrivateServiceUrl] = React.useState<string>('');
 
   const hasGitHub = !!project?.github;
   // Source org/repo from `project.github`, minus the `.myst` suffix if present.

--- a/app/components/toolbar/LaunchButton.tsx
+++ b/app/components/toolbar/LaunchButton.tsx
@@ -1,53 +1,65 @@
-import { useProjectManifest } from '@myst-theme/providers';
+import { useProjectManifest, useSiteManifest } from '@myst-theme/providers';
 import * as Popover from '@radix-ui/react-popover';
 import * as RadioGroup from '@radix-ui/react-radio-group';
 import { CirclePlay } from 'lucide-react';
+import type { SiteManifest } from 'myst-config';
 import React from 'react';
 import { usePage } from '../PageProvider';
+import type { TemplateOptions } from '~/types';
+import { buildColabUrl, buildJupyterHubUrl, type LaunchConfig } from './launchUrls';
 import { Tooltip } from './Tooltip';
-
-const COLAB_BASE_URL = 'https://colab.research.google.com/github/';
-const GITHUB_REPO_SUFFIX = '.notebooks';
-const GITHUB_REPO_BRANCH = 'main';
-
-function buildJupyterHubLaunchUrl({
-  hubBaseUrl,
-  orgRepo,
-  filename,
-}: {
-  hubBaseUrl: string;
-  orgRepo: string;
-  filename: string;
-}) {
-  return `${hubBaseUrl}/jupyter/hub/user-redirect/git-pull?repo=https://github.com/${orgRepo}${GITHUB_REPO_SUFFIX}&branch=${GITHUB_REPO_BRANCH}&urlpath=tree/${
-    orgRepo.split('/')[1]
-  }${GITHUB_REPO_SUFFIX}${filename}`;
-}
 
 function LaunchPanel() {
   const project = useProjectManifest();
   const page = usePage();
+  const launchOptions: TemplateOptions =
+    (useSiteManifest() as SiteManifest & TemplateOptions)?.options ?? {};
   const [service, setService] = React.useState<string | undefined>('colab');
   const [privateServiceUrl, setPrivateServiceUrl] = React.useState<string | undefined>();
 
   const hasGitHub = !!project?.github;
-  // Remove the `.myst` suffix from the orgRepo URL if present.
-  const orgRepo = project?.github 
-                    ? new URL(project?.github).pathname.slice(1).replace(/\.myst$/, '') 
-                    : undefined;
-  const filename = `${page?.location.split('.')[0]}.ipynb`;
+  // Source org/repo from `project.github`, minus the `.myst` suffix if present.
+  const orgRepo = project?.github
+    ? new URL(project.github).pathname.slice(1).replace(/\.myst$/, '')
+    : undefined;
+  const location = page?.location;
+
+  const {
+    launch_repo_url,
+    launch_repo_suffix,
+    launch_branch,
+    launch_notebooks_path,
+    launch_source_path,
+  } = launchOptions;
 
   const handleSelect = React.useCallback((value: string) => setService(value), []);
   const handleLaunch = React.useCallback(() => {
+    if (!orgRepo || !location) return;
+    const config: LaunchConfig = {
+      repoUrl: launch_repo_url,
+      repoSuffix: launch_repo_suffix,
+      branch: launch_branch,
+      notebooksPath: launch_notebooks_path,
+      sourcePath: launch_source_path,
+    };
+    let url: string | undefined;
     if (service === 'colab') {
-      const url = `${COLAB_BASE_URL}${orgRepo}${GITHUB_REPO_SUFFIX}/blob/${GITHUB_REPO_BRANCH}${filename}`;
-      window.open(url, '_blank');
-    } else {
-      if (!privateServiceUrl || !orgRepo) return;
-      const url = buildJupyterHubLaunchUrl({ hubBaseUrl: privateServiceUrl, orgRepo, filename });
-      window.open(url, '_blank');
+      url = buildColabUrl(orgRepo, location, config);
+    } else if (privateServiceUrl) {
+      url = buildJupyterHubUrl(privateServiceUrl, orgRepo, location, config);
     }
-  }, [privateServiceUrl, service, orgRepo, filename]);
+    if (url) window.open(url, '_blank');
+  }, [
+    service,
+    privateServiceUrl,
+    orgRepo,
+    location,
+    launch_repo_url,
+    launch_repo_suffix,
+    launch_branch,
+    launch_notebooks_path,
+    launch_source_path,
+  ]);
 
   return (
     <div className="p-3 space-y-3">

--- a/app/components/toolbar/launchUrls.ts
+++ b/app/components/toolbar/launchUrls.ts
@@ -1,0 +1,91 @@
+// Pure URL/path builders for the notebook launcher.
+//
+// Kept free of React so the logic can be unit-tested in isolation
+// (see tests/unit/launch-urls.test.mjs). This is the MyST-theme port of the
+// book-theme `launch.py` URL construction (`nb_path_to_notebooks`,
+// `path_to_docs` stripping, branch/repo handling). Defaults reproduce the
+// historical hardcoded behaviour, so projects that set no config are unchanged.
+
+export interface LaunchConfig {
+  repoUrl?: string; // launch_repo_url — explicit notebook repo, overrides the derived one
+  repoSuffix?: string; // launch_repo_suffix — appended to the source repo (default ".notebooks")
+  branch?: string; // launch_branch — notebook repo branch (default "main")
+  notebooksPath?: string; // launch_notebooks_path — subdir within the notebook repo (book-theme nb_path_to_notebooks)
+  sourcePath?: string; // launch_source_path — prefix stripped from the page path (book-theme path_to_docs)
+}
+
+export const DEFAULT_REPO_SUFFIX = '.notebooks';
+export const DEFAULT_BRANCH = 'main';
+const COLAB_BASE_URL = 'https://colab.research.google.com/github/';
+
+function trimSlashes(value: string): string {
+  return value.replace(/^\/+|\/+$/g, '');
+}
+
+/**
+ * org/repo for the notebook repository. Derived from the source repo plus the
+ * configured suffix, unless an explicit `launch_repo_url` (full URL or
+ * `org/repo` string) is given.
+ */
+export function notebookOrgRepo(sourceOrgRepo: string, config: LaunchConfig = {}): string {
+  const { repoUrl } = config;
+  if (repoUrl) {
+    let path = repoUrl;
+    try {
+      path = new URL(repoUrl).pathname;
+    } catch {
+      // Not a full URL — treat the value as a bare `org/repo` string.
+    }
+    return trimSlashes(path).replace(/\.git$/, '');
+  }
+  const suffix = config.repoSuffix ?? DEFAULT_REPO_SUFFIX;
+  return `${sourceOrgRepo}${suffix}`;
+}
+
+/**
+ * Path of the notebook within the notebook repo, relative to its root
+ * (no leading slash). Strips the source file extension robustly (handles dots
+ * in directory names), removes the `source_path` prefix, and prepends
+ * `notebooks_path`.
+ */
+export function notebookRelPath(location: string, config: LaunchConfig = {}): string {
+  // Strip leading slash and the trailing source extension only (not every dot).
+  let path = location.replace(/^\/+/, '').replace(/\.[^/.]+$/, '');
+
+  // Strip the source_path (path_to_docs) prefix if the page lives under it.
+  const sourcePath = trimSlashes(config.sourcePath ?? '');
+  if (sourcePath && (path === sourcePath || path.startsWith(`${sourcePath}/`))) {
+    path = trimSlashes(path.slice(sourcePath.length));
+  }
+
+  // Prepend the notebooks_path (nb_path_to_notebooks) subdir.
+  const notebooksPath = trimSlashes(config.notebooksPath ?? '');
+  const prefix = notebooksPath ? `${notebooksPath}/` : '';
+  return `${prefix}${path}.ipynb`;
+}
+
+/** Public Google Colab launch URL for the given page. */
+export function buildColabUrl(
+  sourceOrgRepo: string,
+  location: string,
+  config: LaunchConfig = {},
+): string {
+  const orgRepo = notebookOrgRepo(sourceOrgRepo, config);
+  const branch = config.branch ?? DEFAULT_BRANCH;
+  const relPath = notebookRelPath(location, config);
+  return `${COLAB_BASE_URL}${orgRepo}/blob/${branch}/${relPath}`;
+}
+
+/** Private JupyterHub (nbgitpuller `git-pull`) launch URL for the given page. */
+export function buildJupyterHubUrl(
+  hubBaseUrl: string,
+  sourceOrgRepo: string,
+  location: string,
+  config: LaunchConfig = {},
+): string {
+  const orgRepo = notebookOrgRepo(sourceOrgRepo, config);
+  const repoName = orgRepo.split('/')[1] ?? '';
+  const branch = config.branch ?? DEFAULT_BRANCH;
+  const relPath = notebookRelPath(location, config);
+  return `${hubBaseUrl}/jupyter/hub/user-redirect/git-pull?repo=https://github.com/${orgRepo}&branch=${branch}&urlpath=tree/${repoName}/${relPath}`;
+}

--- a/app/components/toolbar/launchUrls.ts
+++ b/app/components/toolbar/launchUrls.ts
@@ -87,5 +87,9 @@ export function buildJupyterHubUrl(
   const repoName = orgRepo.split('/')[1] ?? '';
   const branch = config.branch ?? DEFAULT_BRANCH;
   const relPath = notebookRelPath(location, config);
-  return `${hubBaseUrl}/jupyter/hub/user-redirect/git-pull?repo=https://github.com/${orgRepo}&branch=${branch}&urlpath=tree/${repoName}/${relPath}`;
+  // Drop a trailing slash on the user-provided hub URL to avoid `//jupyter`.
+  // Query values are left unencoded to match the book-theme `launch.py` /
+  // nbgitpuller format that the production QuantEcon hubs already accept.
+  const base = hubBaseUrl.replace(/\/+$/, '');
+  return `${base}/jupyter/hub/user-redirect/git-pull?repo=https://github.com/${orgRepo}&branch=${branch}&urlpath=tree/${repoName}/${relPath}`;
 }

--- a/app/types.ts
+++ b/app/types.ts
@@ -5,4 +5,16 @@ export interface TemplateOptions {
   hide_footer_links?: boolean;
   outline_maxdepth?: number;
   hide_title_block?: boolean;
+
+  // Notebook launcher configuration (set under `site.options` in myst.yml).
+  // Generalises the previously hardcoded Colab/JupyterHub launch URLs so
+  // non-default branches, repo naming and nested lecture dirs work. All keys
+  // are optional; the defaults reproduce the historical behaviour
+  // (`<github>.notebooks`, branch `main`, flat paths). Mirrors the book-theme
+  // `html_theme_options.launch_buttons` config.
+  launch_repo_url?: string; // explicit notebook repo URL; overrides `<github> + launch_repo_suffix`
+  launch_repo_suffix?: string; // suffix appended to the source repo to locate the notebook repo (default ".notebooks")
+  launch_branch?: string; // notebook repo branch (default "main")
+  launch_notebooks_path?: string; // subdir within the notebook repo where notebooks live (book-theme nb_path_to_notebooks)
+  launch_source_path?: string; // prefix stripped from the page path (book-theme path_to_docs)
 }

--- a/app/types.ts
+++ b/app/types.ts
@@ -10,7 +10,8 @@ export interface TemplateOptions {
   // Generalises the previously hardcoded Colab/JupyterHub launch URLs so
   // non-default branches, repo naming and nested lecture dirs work. All keys
   // are optional; the defaults reproduce the historical behaviour
-  // (`<github>.notebooks`, branch `main`, flat paths). Mirrors the book-theme
+  // (`<github>.notebooks`, branch `main`, and no source/notebooks path
+  // prefixing — the page path is used as-is). Mirrors the book-theme
   // `html_theme_options.launch_buttons` config.
   launch_repo_url?: string; // explicit notebook repo URL; overrides `<github> + launch_repo_suffix`
   launch_repo_suffix?: string; // suffix appended to the source repo to locate the notebook repo (default ".notebooks")

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev:css": "tailwindcss -w -i ./styles/app.css -o app/styles/app.css",
     "dev": "npm run dev:copy && npm run build:thebe && concurrently \"npm run dev:css\" \"remix dev\"",
     "start": "npm run build:css && remix dev",
+    "test:unit": "node --test \"tests/unit/**/*.test.mjs\"",
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots",
     "test:fouc": "playwright test --project=webkit-fouc"

--- a/tests/unit/launch-urls.test.mjs
+++ b/tests/unit/launch-urls.test.mjs
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for the notebook launcher URL/path builders
+ * (app/components/toolbar/launchUrls.ts).
+ *
+ * The module is plain (erasable) TypeScript and free of React, so Node's
+ * built-in type stripping runs it directly under `node --test` — no build
+ * step. Covers the generalisation of the previously hardcoded `.notebooks`
+ * suffix / `main` branch and the nested lecture-dir path handling.
+ *
+ * Run with: npm run test:unit
+ */
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  buildColabUrl,
+  buildJupyterHubUrl,
+  notebookOrgRepo,
+  notebookRelPath,
+} from '../../app/components/toolbar/launchUrls.ts';
+
+const SOURCE = 'QuantEcon/lecture-foo';
+const HUB = 'https://hub.example.org';
+
+test('defaults reproduce the historical Colab URL (backward-compat)', () => {
+  assert.equal(
+    buildColabUrl(SOURCE, '/notebook.ipynb'),
+    'https://colab.research.google.com/github/QuantEcon/lecture-foo.notebooks/blob/main/notebook.ipynb',
+  );
+});
+
+test('defaults reproduce the historical JupyterHub URL (backward-compat)', () => {
+  assert.equal(
+    buildJupyterHubUrl(HUB, SOURCE, '/notebook.ipynb'),
+    'https://hub.example.org/jupyter/hub/user-redirect/git-pull?repo=https://github.com/QuantEcon/lecture-foo.notebooks&branch=main&urlpath=tree/lecture-foo.notebooks/notebook.ipynb',
+  );
+});
+
+test('a source markdown page maps to the .ipynb in the notebook repo', () => {
+  assert.equal(
+    buildColabUrl(SOURCE, '/intro.md'),
+    'https://colab.research.google.com/github/QuantEcon/lecture-foo.notebooks/blob/main/intro.ipynb',
+  );
+});
+
+test('nested lecture dirs are preserved in the path', () => {
+  assert.equal(
+    notebookRelPath('/dynamic_programming/mccall_model.md'),
+    'dynamic_programming/mccall_model.ipynb',
+  );
+  assert.equal(
+    buildColabUrl(SOURCE, '/dynamic_programming/mccall_model.md'),
+    'https://colab.research.google.com/github/QuantEcon/lecture-foo.notebooks/blob/main/dynamic_programming/mccall_model.ipynb',
+  );
+});
+
+test('only the trailing extension is stripped (dots in dir names survive)', () => {
+  // The old `location.split('.')[0]` truncated this to `/python`.
+  assert.equal(notebookRelPath('/python.programming/intro.md'), 'python.programming/intro.ipynb');
+});
+
+test('launch_source_path strips the path_to_docs prefix', () => {
+  const config = { sourcePath: 'lectures' };
+  assert.equal(notebookRelPath('/lectures/dynamic/mccall.md', config), 'dynamic/mccall.ipynb');
+  // A page outside the prefix is left untouched.
+  assert.equal(notebookRelPath('/other/page.md', config), 'other/page.ipynb');
+  // Slashes around the configured prefix are tolerated.
+  assert.equal(notebookRelPath('/lectures/intro.md', { sourcePath: '/lectures/' }), 'intro.ipynb');
+});
+
+test('launch_notebooks_path prepends the nb_path_to_notebooks subdir', () => {
+  assert.equal(
+    notebookRelPath('/intro.md', { notebooksPath: 'notebooks' }),
+    'notebooks/intro.ipynb',
+  );
+  assert.equal(
+    notebookRelPath('/intro.md', { notebooksPath: '/notebooks/' }),
+    'notebooks/intro.ipynb',
+  );
+});
+
+test('launch_branch overrides the default branch', () => {
+  assert.equal(
+    buildColabUrl(SOURCE, '/intro.md', { branch: 'dev' }),
+    'https://colab.research.google.com/github/QuantEcon/lecture-foo.notebooks/blob/dev/intro.ipynb',
+  );
+});
+
+test('launch_repo_suffix overrides the .notebooks suffix', () => {
+  assert.equal(notebookOrgRepo(SOURCE, { repoSuffix: '-notebooks' }), 'QuantEcon/lecture-foo-notebooks');
+  // An empty suffix means the notebook repo is the source repo itself.
+  assert.equal(notebookOrgRepo(SOURCE, { repoSuffix: '' }), 'QuantEcon/lecture-foo');
+});
+
+test('launch_repo_url overrides the derived notebook repo (full URL)', () => {
+  assert.equal(
+    notebookOrgRepo(SOURCE, { repoUrl: 'https://github.com/OtherOrg/custom-nb' }),
+    'OtherOrg/custom-nb',
+  );
+  assert.equal(
+    notebookOrgRepo(SOURCE, { repoUrl: 'https://github.com/OtherOrg/custom-nb.git' }),
+    'OtherOrg/custom-nb',
+  );
+});
+
+test('launch_repo_url also accepts a bare org/repo string', () => {
+  assert.equal(notebookOrgRepo(SOURCE, { repoUrl: 'OtherOrg/custom-nb' }), 'OtherOrg/custom-nb');
+});
+
+test('combined config: source_path strip + notebooks_path + branch + nested dir', () => {
+  const config = {
+    sourcePath: 'lectures',
+    notebooksPath: 'nb',
+    branch: 'release',
+  };
+  assert.equal(
+    buildColabUrl(SOURCE, '/lectures/topic/page.md', config),
+    'https://colab.research.google.com/github/QuantEcon/lecture-foo.notebooks/blob/release/nb/topic/page.ipynb',
+  );
+  assert.equal(
+    buildJupyterHubUrl(HUB, SOURCE, '/lectures/topic/page.md', config),
+    'https://hub.example.org/jupyter/hub/user-redirect/git-pull?repo=https://github.com/QuantEcon/lecture-foo.notebooks&branch=release&urlpath=tree/lecture-foo.notebooks/nb/topic/page.ipynb',
+  );
+});

--- a/tests/unit/launch-urls.test.mjs
+++ b/tests/unit/launch-urls.test.mjs
@@ -7,6 +7,11 @@
  * step. Covers the generalisation of the previously hardcoded `.notebooks`
  * suffix / `main` branch and the nested lecture-dir path handling.
  *
+ * Requires Node >= 23.6 (type stripping of the imported `.ts` is on by
+ * default), matching the CI Node 24 runner. The theme runtime itself still
+ * supports Node >= 20 (`engines.node`); only this dev test needs the newer
+ * Node.
+ *
  * Run with: npm run test:unit
  */
 import assert from 'node:assert/strict';
@@ -32,6 +37,13 @@ test('defaults reproduce the historical Colab URL (backward-compat)', () => {
 test('defaults reproduce the historical JupyterHub URL (backward-compat)', () => {
   assert.equal(
     buildJupyterHubUrl(HUB, SOURCE, '/notebook.ipynb'),
+    'https://hub.example.org/jupyter/hub/user-redirect/git-pull?repo=https://github.com/QuantEcon/lecture-foo.notebooks&branch=main&urlpath=tree/lecture-foo.notebooks/notebook.ipynb',
+  );
+});
+
+test('a trailing slash on the hub URL does not produce a double slash', () => {
+  assert.equal(
+    buildJupyterHubUrl(`${HUB}/`, SOURCE, '/notebook.ipynb'),
     'https://hub.example.org/jupyter/hub/user-redirect/git-pull?repo=https://github.com/QuantEcon/lecture-foo.notebooks&branch=main&urlpath=tree/lecture-foo.notebooks/notebook.ipynb',
   );
 });


### PR DESCRIPTION
## Summary

Generalises the notebook launcher's hardcoded `.notebooks` suffix and `main` branch into optional `site.options` config, and fixes Colab/JupyterHub path handling for nested lecture directories. This is the MyST-theme port of the book-theme `launch.py` URL logic. Part of #88 (Phase 2 — launch parity).

**Backward-compatible:** every new key is optional and its default reproduces today's behaviour, so existing lecture repos — and the current `launch-colab` visual test — are unaffected.

## New `site.options` keys

In MyST there is no `html:` block; `site.options` is the theme-options section (the analog of Sphinx's `html_theme_options`). All keys are optional.

| Key | Default | Purpose (book-theme analog) |
| --- | --- | --- |
| `launch_repo_suffix` | `.notebooks` | Suffix appended to the source repo to locate the notebook repo |
| `launch_branch` | `main` | Notebook repo branch (`nb_branch`) |
| `launch_repo_url` | _(derived)_ | Explicit notebook repo, overrides the derived one (`nb_repository_url`) |
| `launch_notebooks_path` | `""` | Subdir within the notebook repo where notebooks live (`nb_path_to_notebooks`) |
| `launch_source_path` | `""` | Prefix stripped from the page path (`path_to_docs`) |

## Path handling

Fixes nested lecture dirs for both the Colab and Private-JupyterHub URLs: the previous `page.location.split('.')[0]` truncated any path or directory containing a dot (e.g. `python.programming/intro` became `python`). The new builder strips only the trailing source extension, removes the configured `source_path` prefix, and prepends `notebooks_path`.

## Testing

URL logic is extracted to pure, React-free builders in `app/components/toolbar/launchUrls.ts`, unit-tested in `tests/unit/launch-urls.test.mjs` via `node --test` (which imports the `.ts` directly using Node ≥23.6 type-stripping — also runs on the CI Node 24 runner). A new `test:unit` script and CI step run them. 12 tests cover defaults parity (backward-compat), nested dirs, dots-in-dir-names, `source_path`/`notebooks_path`, and the suffix/branch/URL overrides. `npm run compile` and `npm run test:unit` both pass locally.

## Scope / not included

- **Thebe live-compute toggle** — the remaining Phase 2 item; separate follow-up (different files, open design question), so #88 stays open.
- **Removing the Private JupyterHub option (#87)** — kept separate, gated on a maintainer demand signal; this PR therefore generalises both Colab and the hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
